### PR TITLE
Fix Dark Mode Logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://www.zen-browser.app/logos/zen-alpha-white.svgg">
+    <source media="(prefers-color-scheme: dark)" srcset="https://www.zen-browser.app/logos/zen-alpha-white.svg">
     <img src="https://www.zen-browser.app/logos/zen-alpha-black.svg" width="64px">
 </picture>
 </p>


### PR DESCRIPTION
**Issue**: Resolves #34 - Missing README Logo for Dark Mode

**Description**:
This PR fixes the issue where the logo was not displayed correctly in Dark Mode due to an extra 'g' at the end of the URL in the `srcset`. The incorrect URL was causing the logo not to load.

**Changes**:
- Corrected the URL for the Dark Mode logo in the `README.md` file.

**Commit**:
- Updated the `srcset` URL to remove the extra 'g', ensuring the logo displays properly in Dark Mode.

**Screenshots**:
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/e6caf4b9-5a91-4ccc-88de-a592081404f9">
