### PR TITLE
refactor: move footer/navigation to layout.tsx file

### DIFF
--- a/src/app/branding-assets/page.tsx
+++ b/src/app/branding-assets/page.tsx
@@ -1,13 +1,9 @@
 import { BrandingAssets } from "@/components/branding-assets";
-import Footer from "@/components/footer";
-import { Navigation } from "@/components/navigation";
 
 export default function BrandingAssetsPage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-start">
       <BrandingAssets />
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>
   );
 }

--- a/src/app/create-theme/page.tsx
+++ b/src/app/create-theme/page.tsx
@@ -1,13 +1,9 @@
 import CreateThemePage from "@/components/create-theme";
-import Footer from "@/components/footer";
-import { Navigation } from "@/components/navigation";
 
 export default function BrandingAssetsPage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-start">
       <CreateThemePage />
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>
   );
 }

--- a/src/app/download/page.tsx
+++ b/src/app/download/page.tsx
@@ -1,14 +1,10 @@
 
 import DownloadPage from "@/components/download";
-import Footer from "@/components/footer";
-import { Navigation } from "@/components/navigation";
 
 export default function Download() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-start">
       <DownloadPage />
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>   
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
+import Footer from "@/components/footer";
+import { Navigation } from "@/components/navigation";
+import { ThemeProvider } from "@/components/theme-provider";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import { ThemeProvider } from "@/components/theme-provider"
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -26,6 +28,9 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           {children}
+
+          <Footer />  
+          <Navigation /> {/* At the bottom of the page */}
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,11 @@
-"use client";
-
 import Features from "@/components/features";
-import Footer from "@/components/footer";
 import Header from "@/components/header";
-import { Navigation } from "@/components/navigation";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen overflow-x-hidden flex-col items-center justify-start">
       <Header />
       <Features />
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>   
   );
 }

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,8 +1,4 @@
-import Footer from "@/components/footer";
-import { Navigation } from "@/components/navigation";
-import { releaseNoteIsAlpha, releaseNotes } from "@/lib/release-notes";
-import Link from "next/link";
-import Markdown from 'react-markdown'
+import Markdown from 'react-markdown';
 import './markdown.css';
 
 export default function PrivacyPolicy() {
@@ -90,8 +86,6 @@ If you have any questions or concerns about this Privacy Policy or Zen Browser, 
 By using Zen Browser, you agree to this Privacy Policy. Remember, with Zen, your privacy is in your hands.`}
         </Markdown>
       </div>
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>
   )
 }

--- a/src/app/release-notes/[version]/page.tsx
+++ b/src/app/release-notes/[version]/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import Footer from "@/components/footer";
-import { Navigation } from "@/components/navigation";
 import ReleaseNote from "@/components/release-note";
 import { Button } from "@/components/ui/button";
 import { releaseNotes } from "@/lib/release-notes";
@@ -17,6 +15,7 @@ export default function ReleaseNotePage() {
   }
 
   const releaseNote = releaseNotes.find((note) => note.version === version);
+
   if (!releaseNote) {
     return (
       <main className="flex min-h-screen flex-col items-center justify-center">
@@ -28,16 +27,13 @@ export default function ReleaseNotePage() {
             </Button>
           </Link>
         </div>
-        <Footer />
-        <Navigation /> {/* At the bottom of the page */}
       </main>
     );
   }
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center">
       <ReleaseNote data={releaseNote} />
-      <Footer />
-      <Navigation /> {/* At the bottom of the page */}
     </main>
   );
 }

--- a/src/app/release-notes/page.tsx
+++ b/src/app/release-notes/page.tsx
@@ -1,5 +1,3 @@
-import Footer from "@/components/footer";
-import { Navigation } from "@/components/navigation";
 import { releaseNoteIsAlpha, releaseNotes } from "@/lib/release-notes";
 import Link from "next/link";
 
@@ -26,8 +24,6 @@ export default function ReleaseNotes() {
           ))}
         </div>
       </div>
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>
   )
 }

--- a/src/app/themes/[theme]/page.tsx
+++ b/src/app/themes/[theme]/page.tsx
@@ -1,6 +1,4 @@
 "use client";
-import Footer from "@/components/footer";
-import { Navigation } from "@/components/navigation";
 import ThemePage from "@/components/theme-page";
 import { getThemeFromId } from "@/lib/themes";
 import { useParams } from "next/navigation";
@@ -17,8 +15,6 @@ export default async function ThemeInfoPage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-start">
       <ThemePage theme={theme} />
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>
   );
 }

--- a/src/app/themes/page.tsx
+++ b/src/app/themes/page.tsx
@@ -1,14 +1,10 @@
 
-import Footer from "@/components/footer";
 import MarketplacePage from "@/components/marketplace";
-import { Navigation } from "@/components/navigation";
 
 export default function ThemesMarketplace() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-start">
       <MarketplacePage />
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>   
   );
 }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,14 +1,10 @@
 
 import WelcomePage from "@/components/welcome";
-import Footer from "@/components/footer";
-import { Navigation } from "@/components/navigation";
 
 export default function Download() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-start">
       <WelcomePage />
-      <Footer />  
-      <Navigation /> {/* At the bottom of the page */}
     </main>   
   );
 }


### PR DESCRIPTION
This pr closes ##44 issue. It moves the footer/navigation to layout.tsx to avoid unnecessary rendering.