### PR TITLE
fix: Use NextJS recommended config for styled-components

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,17 +3,19 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'raw.githubusercontent.com',
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
       },
     ],
   },
   experimental: {
     serverActions: {
       // edit: updated to new key. Was previously `allowedForwardedHosts`
-      allowedOrigins: ['localhost:3000', 'get-zen.vercel.app'],
+      allowedOrigins: ["localhost:3000", "get-zen.vercel.app"],
     },
-
+  },
+  compiler: {
+    styledComponents: true,
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import { ThemeProvider } from "@/components/theme-provider"
+import { ThemeProvider } from "@/components/theme-provider";
+import StyledComponentsRegistry from "@/lib/styled-components-registry";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -25,7 +26,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {children}
+          <StyledComponentsRegistry>{children}</StyledComponentsRegistry>
         </ThemeProvider>
       </body>
     </html>

--- a/src/lib/styled-components-registry.tsx
+++ b/src/lib/styled-components-registry.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React, { useState } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import { ServerStyleSheet, StyleSheetManager } from "styled-components";
+
+export default function StyledComponentsRegistry({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== "undefined") return <>{children}</>;
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      {children}
+    </StyleSheetManager>
+  );
+}


### PR DESCRIPTION
This fixes `styled-components` styles not rendering on the server side.

Followed this documentation: https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components

For easy debug, disable JS in your devtools and go to `/download`. You should see something similar to this:
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/37621004-5436-46f8-a526-11a1f0ba25ab">

(For reference, this was taken on the production website which, from the looks of it, does not load the `styled-component` regardless for some reason?)

Using this fix, it does load the style:
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/3f4b2e2e-a7e9-4da2-835c-fda7ef107ca5">

If JS is disabled, you can't fill the form anyway, but this is still useful - it will prevent a partial [Flash Of Unstyled Content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) when hydrating on the form area, will also improve layout shift, and by extension UX and SEO.