### PR TITLE
fix(theme-page): resolve sidebar overlapping footer issue

### DIFF
--- a/src/components/theme-page.tsx
+++ b/src/components/theme-page.tsx
@@ -4,7 +4,7 @@ import { Button } from "./ui/button";
 import { useEffect, useState } from "react";
 import Markdown from "react-markdown";
 import '../app/privacy-policy/markdown.css';
-import { ChevronLeft, LoaderCircleIcon, LoaderIcon, LoaderPinwheelIcon, MoveLeftIcon } from "lucide-react";
+import { ChevronLeft, LoaderCircleIcon } from "lucide-react";
 
 export default function ThemePage({ theme }: { theme: ZenTheme }) {
   const [readme, setReadme] = useState<string | null>(null);
@@ -14,7 +14,11 @@ export default function ThemePage({ theme }: { theme: ZenTheme }) {
 
   return (
     <div className="mt-24 lg:mt-56 flex-col lg:flex-row flex mx-auto items-start relative">
-      <div className="flex flex-col relative lg:fixed w-md h-full p-5 lg:p-0 lg:pr-5 mr-5 w-full md:max-w-sm">
+      <div className="flex flex-col relative lg:sticky lg:top-0 w-md h-full p-5 lg:p-0 lg:pr-5 mr-5 w-full md:max-w-sm">
+        <div className="flex mt-2 mb-9 items-center cursor-pointer opacity-70" onClick={() => window.history.back()}>
+          <ChevronLeft className="w-4 h-4 mr-1" />
+          <h3 className="text-md">Go back</h3>
+        </div>
         <Image src={theme.image} alt={theme.name} width={500} height={500} className="w-full object-cover rounded-lg border-2 shadow" />
         <h1 className="text-2xl mt-5 font-bold">{theme.name}</h1>
         <p className="text-sm text-muted-foreground mt-2">{theme.description}</p>
@@ -42,14 +46,10 @@ export default function ThemePage({ theme }: { theme: ZenTheme }) {
         <p id="install-theme-error" className="text-muted-foreground text-sm mt-2">You need to have Zen Browser installed to install this theme. <a href="/download" className="text-blue-500">Download now!</a></p>
       </div>
       <hr className="block my-4 lg:hidden" />
-      <div className="flex flex-col lg:border-l lg:min-h-96 pl-10 lg:ml-[25rem] max-w-xl lg:min-w-96 w-full">
-        <div className="flex my-2 items-center cursor-pointer opacity-70" onClick={() => window.history.back()}>
-          <ChevronLeft className="w-4 h-4 mr-1" />
-          <h3 className="text-md">Go back</h3>
-        </div>
+      <div className="flex flex-col lg:border-l lg:min-h-96 px-5 lg:pl-10 max-w-xl lg:min-w-96 w-full">
         <div id="policy" className="w-full">
           {readme === null ? (
-              <LoaderCircleIcon className="animate-spin w-12 h-12 mx-auto" />
+            <LoaderCircleIcon className="animate-spin w-12 h-12 mx-auto" />
           ) : (
             <Markdown>{`${readme}`}</Markdown>
           )}


### PR DESCRIPTION
### Problem
The sidebar on the theme page was experiencing a layout issue where it would overlap with the footer when scrolling. This bug negatively affected the user experience by disrupting the intended page flow.

### Solution
- **Sticky Effect Preserved:** The sidebar's `lg:fixed` class was replaced with `lg:sticky`, ensuring that the sticky effect is maintained. This change preserves the sidebar's intended behavior of staying in view while scrolling, but now without the bug where it overlaps the footer.
- **Layout Adjustments:** Additional adjustments to padding and margin were made to ensure the sidebar aligns correctly and the overall layout remains consistent across various screen sizes.
- **Code Cleanup:** Unused imports (`LoaderIcon`, `LoaderPinwheelIcon`, `MoveLeftIcon`) from `lucide-react` were removed, resulting in a cleaner and more maintainable codebase.
- **Improved UX:** The "Go back" button was repositioned to the top of the sidebar for a more intuitive user experience.

### Impact
These updates should resolve the layout issue without compromising the sticky behavior of the sidebar. The sidebar now functions as intended, remaining visible while scrolling without causing any visual disruptions.

### Testing
The changes were tested on different screen sizes to confirm that the sidebar no longer overlaps with the footer. The "Go back" button was also tested to ensure it functions correctly and is positioned optimally.

### Additional Context
Please review the theme page to verify that the sticky effect works as expected and that the bug has been fully resolved. Let me know if any issues arise or if further adjustments are needed.

### Before

![1724466288](https://github.com/user-attachments/assets/5d58c58c-6290-4dbf-bb7e-1567405f4d68)

### After

![1724466363](https://github.com/user-attachments/assets/69dde2fa-5b90-4737-b7f9-d739c787a2bd)