### PR TITLE
Change the button text for installation instructions for Mac

### DIFF
--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -248,7 +248,7 @@ export default function DownloadPage() {
                         "https://docs.zen-browser.app/guides/install-macos")
                     }
                   >
-                    Download Zen for MacOS
+                    Installation Instructions for MacOS
                   </Button>
                 </div>
               )}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/137112b6-dac6-4bd8-83d9-b29bb7d4bfaa)

Fixed the button