### PR TITLE
fix: Formatting of features.tsx on ultrawide monitors

### DIFF
--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -63,7 +63,7 @@ export default function Features() {
     return () => clearInterval(interval);
   });
   return (
-    <div className="relative my-32 mx-auto md:border-2 rounded-md md:w-full xl:w-4/5 2xl:w-3/5">
+    <div className="max-w-[1300px] relative my-32 mx-auto md:border-2 rounded-md md:w-full xl:w-4/5 2xl:w-3/5">
       <div className="grid grid-cols-1 md:grid-cols-3 md:grid-rows-10 w-full">
         <div className="items-center justify-center flex flex-col p-16">
           <div className="rounded-full px-8 py-3 shadow border-2 flex items-center justify-center">


### PR DESCRIPTION
This addresses #93

The styling for ultra-wide monitors can be fixed by simply adding a max-width to the `Features` component. 

<figure>
<figcaption>Styling of the features before</figcaption>
<img width="1320" alt="Screenshot 2024-08-25 at 10 39 47 PM" src="https://github.com/user-attachments/assets/e6ebac6b-cf64-4ca0-8dcf-f9cfda529b28">
</figure>
<br><br>
<figure>
<figcaption>Styling of the features after</figcaption>
<img width="1320" alt="Screenshot 2024-08-25 at 10 39 36 PM" src="https://github.com/user-attachments/assets/9319d581-027c-46a3-899b-54fe72effed5">
</figure>