### PR TITLE
fix:Responsive design on image carousel

### DIFF
--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -339,11 +339,11 @@ export default function Features() {
           </div>
         </div>
         <div className="flex flex-col border-t-2 md:col-span-3 grid grid-cols-1 md:grid-cols-3 grid-rows-2 row-span-2">
-          <div className="relative p-16 border-r-2 flex flex-col items-center justify-center row-span-2 col-span-2">
+          <div className="relative px-16 pt-16 md:pb-16 border-r-2 flex flex-col items-center justify-center row-span-2 col-span-2">
             <div className="relative w-full h-full flex items-center justify-center">
               <img
                 src="/split-view.png"
-                className={ny("absolute hover:scale-105 rounded-md w-full shadow-md dark:shadow-none dark:border-2 border-blue-500 transform transition-all duration-300",
+                className={ny("hover:scale-105 rounded-md w-full shadow-md dark:shadow-none dark:border-2 border-blue-500 transform transition-all duration-300",
                   feature === 0 ? 'translate-x-0' : '-translate-x-1/4 opacity-0'
                 )}
               />
@@ -361,7 +361,7 @@ export default function Features() {
               />
             </div>
           </div>
-          <div className="p-16 flex flex-col items-center justify-around row-span-2">
+          <div className="px-16 pt-16 md:pb-16 flex flex-col items-start justify-around row-span-2">
             <div className={ny(feature === 0 ? 'opacity-100' : 'opacity-50', "mt-10 md:mt-0 transform transition-all duration-200 cursor-pointer")} onClick={() => setFeature(0)}>
               <h2 className="text-lg font-bold ml-4 flex items-center">
                 <SplitSquareHorizontal className="w-4 h-4 mr-2" />


### PR DESCRIPTION
This is a fix for #101 

See the below image:
<img width="1366" alt="Screenshot 2024-08-25 at 11 37 56 PM" src="https://github.com/user-attachments/assets/413a3080-e82e-455d-9bb3-c53cf257c591">

- The image is overflowing over the border of the div containing it and the text.
- The list items are not aligned.

The cause of this is that all three `<img />` tags used in the carousel are "position: absolute" and the `<div />` containing the `<img />` tags does not have a defined height, therefore the `<div />` collapses to zero height and the `<img />` tags "float" above their parent element. 

The fix is to make one of the `<img />` tags a "position: block" so that it is "tangible" and affects the styling of the surrounding elements. 

<img width="1366" alt="Screenshot 2024-08-25 at 11 28 03 PM" src="https://github.com/user-attachments/assets/d0228e8f-9cfc-482d-abf6-1fcb4b6cb0af">

Making this adjustment led to a lot of whitespace between the images and text so I changed the "p-16" classes to "px-16 pt-16 md:pb-16" classes so that there is less whitespace on mobile. 

<img width="1366" alt="Screenshot 2024-08-25 at 11 29 39 PM" src="https://github.com/user-attachments/assets/3b6daa88-05b7-4ae0-a9ad-687518fdb2f0">

Finally the list items are not aligned because they are vertically centered by the parent element having "flex item-center justify-center". This isn't correct and so I have changed it to "flex item-start justify-center".

Below is the same aspect ratio as that first screenshot and after the above changes, the previous styling issues are not present

<img width="1366" alt="Screenshot 2024-08-25 at 11 39 25 PM" src="https://github.com/user-attachments/assets/8e5adf4c-102c-4d36-8ac8-5191464d2a72">
