### PR TITLE
fix: Disable onClick for NavigationMenuTrigger for 1000ms on first hover

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,52 +1,57 @@
-"use client"
- 
-import * as React from "react"
-import Link from "next/link"
- 
-import { ny } from "@/lib/utils"
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { ny } from "@/lib/utils";
 import {
   NavigationMenu,
   NavigationMenuContent,
   NavigationMenuItem,
   NavigationMenuLink,
   NavigationMenuList,
-  NavigationMenuTrigger,
-  navigationMenuTriggerStyle,
-} from "@/components/ui/navigation-menu"
-import Logo from "./logo"
-import { ModeToggle } from "./mode-toggle"
-import { MobileNav } from "./mobile-nav"
-import { HeartIcon } from "lucide-react"
-import { HeartFilledIcon } from "@radix-ui/react-icons"
- 
-export const components: { title: string; href: string; description: string }[] = [
+} from "@/components/ui/navigation-menu";
+import Logo from "./logo";
+import { ModeToggle } from "./mode-toggle";
+import { MobileNav } from "./mobile-nav";
+import { HeartIcon } from "lucide-react";
+import { HeartFilledIcon } from "@radix-ui/react-icons";
+import NavigationMenuTrigger from "./ui/navigation-menu-trigger";
+
+export const components: {
+  title: string;
+  href: string;
+  description: string;
+}[] = [
   {
     title: "Privacy Policy",
     href: "/privacy-policy",
-    description: "Learn how we handle your data. Don't worry, we don't collect anything!",
+    description:
+      "Learn how we handle your data. Don't worry, we don't collect anything!",
   },
   {
     title: "Discord",
     href: "https://discord.gg/nnShMQzR4b",
-    description: "Join our Discord server to chat with the community."
+    description: "Join our Discord server to chat with the community.",
   },
   {
     title: "Source Code",
     href: "https://github.com/zen-browser",
-    description: "Check out our source code on GitHub and leave a star!"
+    description: "Check out our source code on GitHub and leave a star!",
   },
   {
     title: "Branding Assets",
     href: "/branding-assets",
-    description: "Download Zen Browser branding assets for your website or project."
+    description:
+      "Download Zen Browser branding assets for your website or project.",
   },
   {
     title: "Documentation",
     href: "https://docs.zen-browser.app/",
-    description: "Learn how to use Zen Browser and build your own themes."
-  }
-]
- 
+    description: "Learn how to use Zen Browser and build your own themes.",
+  },
+];
+
 export function Navigation() {
   return (
     <div className="bg-background z-40 top-0 left-0 w-full flex fixed border-b border-grey p-2 items-center justify-center">
@@ -102,13 +107,15 @@ export function Navigation() {
                   title="Patreon"
                   href="https://patreon.com/zen_browser?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink"
                 >
-                  Support us on Patreon and get exclusive rewards and keep the project alive.
+                  Support us on Patreon and get exclusive rewards and keep the
+                  project alive.
                 </ListItem>
                 <ListItem
                   title="Ko-fi"
                   href="https://ko-fi.com/zen_browser?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink"
                 >
-                  Ko-fi is a way to support us with a one-time donation and help us keep the project alive.
+                  Ko-fi is a way to support us with a one-time donation and help
+                  us keep the project alive.
                 </ListItem>
               </ul>
             </NavigationMenuContent>
@@ -133,9 +140,9 @@ export function Navigation() {
         </NavigationMenuList>
       </NavigationMenu>
     </div>
-  )
+  );
 }
- 
+
 const ListItem = React.forwardRef<
   React.ElementRef<"a">,
   React.ComponentPropsWithoutRef<"a">
@@ -158,6 +165,6 @@ const ListItem = React.forwardRef<
         </a>
       </NavigationMenuLink>
     </li>
-  )
-})
-ListItem.displayName = "ListItem"
+  );
+});
+ListItem.displayName = "ListItem";

--- a/src/components/ui/navigation-menu-trigger.tsx
+++ b/src/components/ui/navigation-menu-trigger.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { NavigationMenuTrigger as OriginalNavigationMenuTrigger } from "./navigation-menu";
+
+export default function NavigationMenuTrigger({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // init disable state
+  const [disable, setDisable] = useState(false);
+
+  // init reference array
+  const targetRef = useRef<HTMLButtonElement[]>([]);
+
+  // Create observer on first render
+  useEffect(() => {
+    // Callback function
+    const observerCallback = (mutationsList: MutationRecord[]) => {
+      for (const mutation of mutationsList) {
+        console.log(mutation.target);
+        if (
+          mutation.type === "attributes" &&
+          mutation.attributeName === "data-state" &&
+          (mutation.target as HTMLElement).dataset.state === "open"
+        ) {
+          setDisable(true);
+          const timeout = setTimeout(() => {
+            setDisable(false);
+            clearTimeout(timeout);
+          }, 1000);
+        }
+      }
+    };
+
+    // Init MutationObserver
+    const observer = new MutationObserver(observerCallback);
+
+    // Add ref nodes to observer watch
+    targetRef.current.forEach((element) => {
+      if (element) {
+        observer.observe(element, {
+          attributes: true,
+        });
+      }
+    });
+
+    // Disconnect on dismount
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <OriginalNavigationMenuTrigger
+      ref={(ref) => {
+        if (ref) {
+          targetRef.current[0] = ref;
+        }
+      }}
+      onClick={(e) => {
+        if (disable) {
+          e.preventDefault();
+        }
+      }}
+    >
+      {children}
+    </OriginalNavigationMenuTrigger>
+  );
+}

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
-import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
-import { cva } from "class-variance-authority"
-import { ChevronDown } from "lucide-react"
+import * as React from "react";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDown } from "lucide-react";
 
-import { ny } from "@/lib/utils"
+import { ny } from "@/lib/utils";
 
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,
@@ -20,8 +20,8 @@ const NavigationMenu = React.forwardRef<
     {children}
     <NavigationMenuViewport />
   </NavigationMenuPrimitive.Root>
-))
-NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName
+));
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;
 
 const NavigationMenuList = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.List>,
@@ -35,14 +35,14 @@ const NavigationMenuList = React.forwardRef<
     )}
     {...props}
   />
-))
-NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
+));
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 
-const NavigationMenuItem = NavigationMenuPrimitive.Item
+const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
   "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
-)
+);
 
 const NavigationMenuTrigger = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
@@ -59,8 +59,8 @@ const NavigationMenuTrigger = React.forwardRef<
       aria-hidden="true"
     />
   </NavigationMenuPrimitive.Trigger>
-))
-NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName
+));
+NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName;
 
 const NavigationMenuContent = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Content>,
@@ -74,10 +74,10 @@ const NavigationMenuContent = React.forwardRef<
     )}
     {...props}
   />
-))
-NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName
+));
+NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
 
-const NavigationMenuLink = NavigationMenuPrimitive.Link
+const NavigationMenuLink = NavigationMenuPrimitive.Link;
 
 const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
@@ -93,9 +93,9 @@ const NavigationMenuViewport = React.forwardRef<
       {...props}
     />
   </div>
-))
+));
 NavigationMenuViewport.displayName =
-  NavigationMenuPrimitive.Viewport.displayName
+  NavigationMenuPrimitive.Viewport.displayName;
 
 const NavigationMenuIndicator = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
@@ -111,9 +111,9 @@ const NavigationMenuIndicator = React.forwardRef<
   >
     <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
   </NavigationMenuPrimitive.Indicator>
-))
+));
 NavigationMenuIndicator.displayName =
-  NavigationMenuPrimitive.Indicator.displayName
+  NavigationMenuPrimitive.Indicator.displayName;
 
 export {
   navigationMenuTriggerStyle,
@@ -125,4 +125,4 @@ export {
   NavigationMenuLink,
   NavigationMenuIndicator,
   NavigationMenuViewport,
-}
+};


### PR DESCRIPTION
This fix is based on [this issue with radix primitives](https://github.com/radix-ui/primitives/issues/1630#issuecomment-1545995075)

You can see Theo in the video clicking on the navigation menu instinctively, but the click triggers the "close state", because the hover has already triggered the "open state".

This fix makes sure to disable the onClick event for a short period to avoid this janky UX.