### PR TITLE
Spacing issue in comparison chart #111

### DIFF
--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -229,7 +229,7 @@ export default function Features() {
                     />
                     Zen
                   </TableHead>
-                  <TableHead className="py-2 pl-4 lg:pr-0 pr-2 font-bold text-center opacity-60">
+                  <TableHead className="py-2 lg:pr-2 font-bold text-center opacity-60 mr-4">
                     <Image
                       height={32}
                       width={32}


### PR DESCRIPTION
This is a fix for https://github.com/zen-browser/www/issues/111
![Screenshot 2024-08-27 175227](https://github.com/user-attachments/assets/5457e2fb-b997-49d4-9a3c-38bc48b25fe5)
This PR addresses a bug where the text elements for "Floorp" and "LibreWolf" were not properly spaced in the browser comparison table, specifically in Chrome.

### Changes Made:
- Adjusted the CSS class by  adding to `mr-4`.
- Updated padding values to ensure consistent spacing across all screen sizes and browsers.
- Ensured proper alignment of elements by simplifying the padding rules.

### Why These Changes:
- The issue was only occurring in Chrome, FireFox, likely due to how it handles inline-block elements and margin collapsing. These changes ensure that the text elements are properly spaced across all browsers, providing a consistent layout.

### Testing:
- Verified the changes in Chrome, Firefox, and Edge to confirm that the spacing is correct in all browsers.
