### PR TITLE
fix: Responsive design on medium windows

### DIFF
--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -53,7 +53,7 @@ import { getAllThemes, ZenTheme } from '@/lib/themes';
 
 function Checkmark() {
   return (
-    <CheckIcon className="text-black rounded-full bg-green-500 dark:bg-green-400 p-1 w-7 h-7" />
+    <CheckIcon className="text-black rounded-full bg-green-500 dark:bg-green-400 p-1 w-7 h-7 flex-none" />
   );
 }
 

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -80,7 +80,7 @@ export default function Features() {
   return (
     <section className="flex-col w-full" id="features">
       <div className='w-full md:w-5/6 lg:w-3/4 flex flex-col lg:flex-row md:rounded-md mx-auto bg-surface mt-16 shadow'>
-        <div className="md:w-1/2 p-5 lg:p-12">
+        <div className="p-5 lg:p-12 flex-1">
           <div className="flex p-12 flex-col justify-center">
             <h3 className='text-4xl font-medium text-gray-800 dark:text-gray-100'>Your Browser, your way <PaintBucket className='inline w-10 h-10'></PaintBucket></h3>
             <p className='text-lg mt-4 text-gray-600 dark:text-gray-300'>With Zen's Theme Store, you can customize your browsing experience to reflect your unique style and preferences. Choose from a wide array of themes, colors, and layouts to make Zen truly your own, transforming your browser into a personalized digital space.</p>
@@ -91,7 +91,7 @@ export default function Features() {
           </div>
         </div>
         <div className="border-t lg:border-t-0 lg:border-l h-[1px] lg:h-[unset] lg:w-[1px] mx-2"></div>
-        <div className="md:w-1/2 p-5 lg:p-12">
+        <div className="p-5 lg:p-12 flex-1">
           <div className="flex p-12 flex-col justify-center">
             <h3 className='text-4xl font-medium text-gray-800 dark:text-gray-100'>Community driven and Open Source <Link1Icon className='inline w-10 h-10'></Link1Icon></h3>
             <p className='text-lg mt-4 text-gray-600 dark:text-gray-300'>Zen thrives on the contributions of its vibrant community. As an open-source project, Zen encourages collaboration and innovation, allowing users and developers alike to shape the future of the browser.</p>
@@ -144,7 +144,7 @@ export default function Features() {
         </div>
         <img src="https://cdn.jsdelivr.net/gh/zen-browser/www/public/browser-1.png" alt="Zen Browser" className="rounded-md lg:w-1/2" />
       </div>
-      <div className='w-full md:w-5/6 lg:w-3/4 flex flex-col lg:flex-row md:rounded-md lg:mx-auto bg-surface mt-36 shadow'>
+      <div className='w-full md:w-5/6 lg:w-3/4 flex flex-col lg:flex-row md:rounded-md mx-auto bg-surface mt-36 shadow'>
         <img src="https://cdn.jsdelivr.net/gh/zen-browser/www/public/browser-2.png" alt="Zen Browser" className="rounded-md lg:w-1/2" />
         <div className='p-16 lg:w-1/2 flex flex-col justify-center'>
           <h1 className='text-4xl font-medium text-gray-800 dark:text-gray-100'>Split Views</h1>


### PR DESCRIPTION
Fixing the styling issues when a user opens the site on a medium width desktop browser. 

### Fix 1 - Half width on medium
Currently making each section half of their parent div on **large** windows is done by manually setting `md:w-1/2` on each section. 
The issue with this is that on medium windows the width is still half and the styling breaks. This could be fixed by changing `lg:w-1/2` but a more elegant solution is to set each child to `flex-1` so they both have equal... growing ability?... flex priority?... idk. Basically, it gives them both the same amount of entitlement to the available space. 

Before Large Window:
<img width="500" alt="Screenshot 2024-08-30 at 11 38 21 AM" src="https://github.com/user-attachments/assets/165aaed1-ff1c-4959-b9d1-6218e23e6c97"><br>
Before Medium Window:
<img width="400" alt="Screenshot 2024-08-30 at 11 37 56 AM" src="https://github.com/user-attachments/assets/73df2fc8-effb-408b-b489-e115e80e77bb">

After Large Window:
<img width="500" alt="Screenshot 2024-08-30 at 11 38 29 AM" src="https://github.com/user-attachments/assets/92c8723e-169d-4f5f-9cf3-270d29834e6a"><br>
After Medium Window:
<img width="400" alt="Screenshot 2024-08-30 at 11 38 07 AM" src="https://github.com/user-attachments/assets/654c744a-995d-4763-aaa4-0d024374f760">

### Fix 2 - Centering Split Views
Split view container was set to `lg:mx-auto` on the split-views container but was just `mx-auto` on all the others
 
Before:
<img width="400" alt="Screenshot 2024-08-30 at 11 40 46 AM" src="https://github.com/user-attachments/assets/f886c82e-91dc-461c-8bde-c2842329cc10">
After:
<img width="400" alt="Screenshot 2024-08-30 at 11 40 52 AM" src="https://github.com/user-attachments/assets/0b1f1689-4f81-49d2-a624-2ec61b54e309">


