### PR TITLE
feat(navigation): improve mobile nav readability and unify links

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -2,6 +2,6 @@
     "navigation": {
         "getting-started": "Erste Schritte",
         "donate": "Spenden",
-        "useful-links": "Nützliche Links"
+        "resources": "Ressourcen"
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,6 +2,6 @@
     "navigation": {
         "getting-started": "Getting Started",
         "donate": "Donate",
-        "useful-links": "Useful Links"
+        "resources": "Resources"
     }
 }

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -263,9 +263,9 @@ export default function Features() {
         <div className="flex p-16 lg:w-1/2 flex-col justify-center">
           <h3 className='text-4xl font-medium text-gray-800 dark:text-gray-100'>Even more convinced? <HeartHandshake className='inline text-red-500 h-10 w-10' /></h3>
           <p className='text-lg mt-4 text-gray-600 dark:text-gray-300'>Help support the development of Zen Browser by donating to our cause.</p>
-          <div className="relative mt-8 flex">
-            <Button variant="ghost" onClick={() => window.open('https://patreon.com/zen_browser', '_blank')}>Patreon <ExternalLinkIcon className='opacity-50 h-4 w-4 ml-4' /></Button>
-            <Button className="ml-8" variant="ghost" onClick={() => window.open('https://ko-fi.com/zen_browser', '_blank')}>Ko-fi <ExternalLinkIcon className='opacity-50 h-4 w-4 ml-4' /></Button>
+          <div className="md:grid md:grid-cols-2 mt-8">
+            <Button variant="ghost" className="inline-flex" onClick={() => window.open('https://patreon.com/zen_browser', '_blank')}>Patreon <ExternalLinkIcon className='opacity-50 h-4 w-4 ml-4' /></Button>
+            <Button variant="ghost" className="inline-flex" onClick={() => window.open('https://ko-fi.com/zen_browser', '_blank')}>Ko-fi <ExternalLinkIcon className='opacity-50 h-4 w-4 ml-4' /></Button>
           </div>
         </div>
       </div>

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client"
 
 import { SidebarOpen } from 'lucide-react'
 import type { LinkProps } from 'next/link'
@@ -10,69 +10,90 @@ import { Button } from './ui/button'
 import { ScrollArea } from './ui/scroll-area'
 import Logo from './logo'
 import { ny } from '@/lib/utils'
-import { components } from './navigation'
+import { jsonData } from './navigation'
+import { HeartFilledIcon } from "@radix-ui/react-icons"
+import Socials from './socials'
+import { buttonVariants } from "@/components/ui/button"
+import { useTranslations } from "next-intl";
 
 export function MobileNav() {
-   const [open, setOpen] = React.useState(false)
+
+   const t = useTranslations('navigation');
 
    return (
-      <Sheet open={open} onOpenChange={setOpen}>
-         <SheetTrigger asChild>
-            <div className="z-40 flex w-full items-center space-between sm:hidden">
-               <Logo className="size-6 ml-4" />
-               <Button
-                  variant="ghost"
-                  className="mr-2 px-0 ml-auto text-base hover:bg-transparent focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
-               >
-                  <SidebarOpen className="size-6" />
-                  <span className="sr-only">Toggle Menu</span>
-               </Button>
-            </div>
-         </SheetTrigger>
+      <Sheet>
+         <div className="z-40 flex w-full items-center justify-between sm:hidden">
+            <SheetTrigger>
+                  <div className="grid gap-4 grid-cols-2 items-center">
+                     <div
+                        className={ny(
+                           buttonVariants({
+                           variant: "ghost",
+                           }),
+                           "h-8 w-8 px-0 ml-2 text-base hover:bg-transparent focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+                        )}
+                     >
+                        <SidebarOpen className="size-6" />
+                        <span className="sr-only">Toggle Menu</span>
+                     </div>
+                     <Logo className="size-6" />
+                  </div>
+            </SheetTrigger>
+            <Socials />
+         </div>
          <SheetContent side="left" className="pr-0">
             <MobileLink
                href="/"
                className="flex items-center"
-               onOpenChange={setOpen}
             >
                <Logo withText />
             </MobileLink>
             <ScrollArea className="my-4 h-[calc(100vh-8rem)] pb-10 pl-6">
-               <div className="flex flex-col space-y-3">
-                  <MobileLink
-                     href="/download"
-                    onOpenChange={setOpen}
-                  >
-                    Download
-                  </MobileLink>
-                  <MobileLink
-                     href="/themes"
-                    onOpenChange={setOpen}
-                  >
-                    Theme Store
-                  </MobileLink>
-                  <MobileLink
-                     href="/release-notes"
-                    onOpenChange={setOpen}
-                  >
-                    Release Notes
-                  </MobileLink>
-                  <MobileLink
-                     href="https://patreon.com/zen_browser?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink"
-                     onOpenChange={setOpen}
-                  >
-                     Donate {"<"}3
-                  </MobileLink>
-                  {components.map(({title, href, description}) => (
+               <div className="flex flex-col space-y-2">
+                  <div className="flex flex-col space-y-3 pt-6">
+                     <h4 className="font-medium">{t('getting-started')}</h4>
+                  </div>
+                  {jsonData.mainLinks.map(({title, href}) => (
                      <MobileLink
                         href={href}
                         key={href}
-                        onOpenChange={setOpen}
+                        className="text-muted-foreground"
                      >
                         {title}
                      </MobileLink>
                   ))}
-                </div>
+               </div>
+               <div className="flex flex-col space-y-2">
+                  <div className="flex flex-col space-y-3 pt-6">
+                     <h4 className="inline-flex items-center font-medium">              
+                        {t('donate')}
+                        <HeartFilledIcon className="ml-2 text-red-500" />
+                     </h4>
+                  </div>
+                  {jsonData.donationLinks.map(({title, href}) => (
+                     <MobileLink
+                        href={href}
+                        key={href}
+                        className="text-muted-foreground"
+                     >
+                        {title}
+                     </MobileLink>
+                  ))}
+               </div>
+               <div className="flex flex-col space-y-2">
+               <div className="flex flex-col space-y-3 pt-6">
+                  <h4 className="font-medium">{t('resources')}</h4>
+               </div>
+               {jsonData.usefulLinks.map(({title, href}) => (
+                  <MobileLink
+                     href={href}
+                     key={href}
+                     className="text-muted-foreground"
+                  >
+                     {title}
+                  </MobileLink>
+               ))}
+               </div>
             </ScrollArea>
          </SheetContent>
       </Sheet>
@@ -98,7 +119,6 @@ function MobileLink({
          href={href.toString()}
          onClick={() => {
             router.push(href.toString())
-            onOpenChange?.(false)
          }}
          className={ny(className)}
          {...props}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -11,43 +11,31 @@ import {
   NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
-  navigationMenuTriggerStyle,
-} from "@/components/ui/navigation-menu"
-import Logo from "./logo"
-import { ModeToggle } from "./mode-toggle"
-import { MobileNav } from "./mobile-nav"
+} from "@/components/ui/navigation-menu";
+import Logo from "./logo";
+import Socials from "./socials";
+import { MobileNav } from "./mobile-nav";
 import { HeartIcon } from "lucide-react"
-import { HeartFilledIcon } from "@radix-ui/react-icons"
+import { HeartFilledIcon } from "@radix-ui/react-icons";
 import { useTranslations } from "next-intl";
- 
-export const components: { title: string; href: string; description: string }[] = [
-  {
-    title: "Privacy Policy",
-    href: "/privacy-policy",
-    description: "Learn how we handle your data. Don't worry, we don't collect anything!",
-  },
-  {
-    title: "Discord",
-    href: "https://discord.gg/nnShMQzR4b",
-    description: "Join our Discord server to chat with the community."
-  },
-  {
-    title: "Source Code",
-    href: "https://github.com/zen-browser",
-    description: "Check out our source code on GitHub and leave a star!"
-  },
-  {
-    title: "Branding Assets",
-    href: "/branding-assets",
-    description: "Download Zen Browser branding assets for your website or project."
-  },
-  {
-    title: "Documentation",
-    href: "https://docs.zen-browser.app/",
-    description: "Learn how to use Zen Browser and build your own themes."
-  }
-]
- 
+
+export const jsonData = {
+  mainLinks: [
+    { title: "Download", href: "/download", description: "Start using Zen Browser today with just a few clicks." },
+    { title: "Themes Store", href: "/themes", description: "Customize your browser with a variety of themes!" },
+    { title: "Release Notes", href: "/release-notes", description: "Stay up to date with the latest changes." }
+  ],
+  donationLinks: [
+    { title: "Patreon", href: "https://patreon.com/zen_browser?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink", description: "Support us on Patreon and get exclusive rewards and keep the project alive." },
+    { title: "Ko-fi", href: "https://ko-fi.com/zen_browser?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink", description: "Ko-fi is a way to support us with a one-time donation and help us keep the project alive." }
+  ],
+  usefulLinks: [
+    { title: "Privacy Policy", href: "/privacy-policy", description: "Learn how we handle your data. Don't worry, we don't collect anything!" },
+    { title: "Branding Assets", href: "/branding-assets", description: "Download Zen Browser branding assets for your website or project." },
+    { title: "Documentation", href: "https://docs.zen-browser.app/", description: "Learn how to use Zen Browser and build your own themes." }
+  ]
+}
+
 export function Navigation() {
 
   const t = useTranslations('navigation');
@@ -56,8 +44,8 @@ export function Navigation() {
     <div className="bg-background z-40 top-0 left-0 w-full flex fixed border-b border-grey p-2 items-center justify-center">
       <MobileNav />
       <NavigationMenu>
-        <NavigationMenuList className="w-full hidden py-3 sm:flex">
-          <NavigationMenuItem className="cursor-pointer mr-20">
+        <NavigationMenuList className="w-ful space-x-8 hidden py-3 sm:flex">
+          <NavigationMenuItem className="cursor-pointer">
             <NavigationMenuLink href="/">
               <Logo withText />
             </NavigationMenuLink>
@@ -83,15 +71,11 @@ export function Navigation() {
                     </a>
                   </NavigationMenuLink>
                 </li>
-                <ListItem href="/download" title="Download">
-                  Start using Zen Browser today with just a few clicks.
-                </ListItem>
-                <ListItem href="/themes" title="Themes Store">
-                  Customize your browser with a variety of themes!
-                </ListItem>
-                <ListItem href="/release-notes" title="Release Notes">
-                  Stay up to date with the latest changes.
-                </ListItem>
+                {jsonData.mainLinks.map((link) => (
+                  <ListItem key={link.title} href={link.href} title={link.title}>
+                    {link.description}
+                  </ListItem>
+                ))}
               </ul>
             </NavigationMenuContent>
           </NavigationMenuItem>
@@ -101,45 +85,34 @@ export function Navigation() {
               <span className="ml-2">{t('donate')}</span>
             </NavigationMenuTrigger>
             <NavigationMenuContent>
-              <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px] ">
-                <ListItem
-                  title="Patreon"
-                  href="https://patreon.com/zen_browser?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink"
-                >
-                  Support us on Patreon and get exclusive rewards and keep the project alive.
-                </ListItem>
-                <ListItem
-                  title="Ko-fi"
-                  href="https://ko-fi.com/zen_browser?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink"
-                >
-                  Ko-fi is a way to support us with a one-time donation and help us keep the project alive.
-                </ListItem>
+              <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px]">
+                {jsonData.donationLinks.map((link) => (
+                  <ListItem key={link.title} href={link.href} title={link.title}>
+                    {link.description}
+                  </ListItem>
+                ))}
               </ul>
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem>
-            <NavigationMenuTrigger>{t('useful-links')}</NavigationMenuTrigger>
+            <NavigationMenuTrigger>{t('resources')}</NavigationMenuTrigger>
             <NavigationMenuContent>
-              <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px] ">
-                {components.map((component) => (
-                  <ListItem
-                    key={component.title}
-                    title={component.title}
-                    href={component.href}
-                  >
+              <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px]">
+                {jsonData.usefulLinks.map((component) => (
+                  <ListItem key={component.title} title={component.title} href={component.href}>
                     {component.description}
                   </ListItem>
                 ))}
               </ul>
             </NavigationMenuContent>
           </NavigationMenuItem>
-          <ModeToggle />
+            <Socials />
         </NavigationMenuList>
       </NavigationMenu>
     </div>
   )
 }
- 
+
 const ListItem = React.forwardRef<
   React.ElementRef<"a">,
   React.ComponentPropsWithoutRef<"a">

--- a/src/components/socials.tsx
+++ b/src/components/socials.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { DiscordLogoIcon } from "@radix-ui/react-icons";
+import { GitHubLogoIcon } from "@radix-ui/react-icons";
+import { ModeToggle } from './mode-toggle';
+import Link from 'next/link';
+import { Button } from './ui/button';
+
+export default function Socials() {
+  return (
+    <div>
+        <Link
+              href="https://github.com/zen-browser"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Button variant="ghost" size="icon">
+                <GitHubLogoIcon className="h-[1.2rem] w-[1.2rem]"/>
+                <span className="sr-only">GitHub</span>
+              </Button>
+            </Link>
+            <Link
+              href="https://discord.gg/nnShMQzR4b"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Button variant="ghost" size="icon">
+                <DiscordLogoIcon className="h-[1.2rem] w-[1.2rem]"/>
+                <span className="sr-only">Twitter</span>
+              </Button>
+        </Link>
+        <ModeToggle />
+    </div>
+  )
+}


### PR DESCRIPTION
- Rewrote mobile nav to improve readability by splitting links into categories, similar to the navigation component (see 2️⃣)
- Unified all links into JSON for consistent mapping on both mobile nav and navigation component
- Added social component for quick access to social media links and light/dark mode toggle on small and large screens (see 1️⃣ and 3️⃣)
- Renamed "useful links" to "resources" in messages
- Fixed CSS for donation buttons on the features page (see 4️⃣)

1️⃣ before:
![screen 365](https://github.com/user-attachments/assets/69a5938f-9567-4f48-809a-c2bec0b14533)

1️⃣ after:
![screen 364](https://github.com/user-attachments/assets/de8cc494-d21d-44e8-9d28-68ca3eda6c73)

2️⃣ before:
![screen 367](https://github.com/user-attachments/assets/2bb8ea8b-e778-4b48-972c-fc5b3565960b)

2️⃣ after:
![screen 366](https://github.com/user-attachments/assets/5bcfe994-61a6-48ca-aa94-2a45c5fd7c3f)

3️⃣ before:
![screen 368](https://github.com/user-attachments/assets/a5009c49-02e9-4868-9d4b-57ef845f0e58)

3️⃣ after:
![screen 369](https://github.com/user-attachments/assets/54f4a1e7-33b2-4317-9495-80e778a3e7c2)

4️⃣ before:
![screen 371](https://github.com/user-attachments/assets/e6ba9cf7-46dc-43ae-8c91-cd3a5bc36157)

4️⃣ after:
![screen 372](https://github.com/user-attachments/assets/02221797-e748-4234-be2e-ed3702ba7715)
