### PR TITLE
fix: Smooth scrolling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,12 +85,13 @@
 }
 
 @layer base {
+   html {
+      @apply scroll-smooth;
+   }
    * {
       @apply border-border;
    }
    body {
       @apply bg-background text-foreground;
-
-      scroll-behavior: smooth;
    }
 }


### PR DESCRIPTION
Smooth scrolling wasn't working due to the `scroll-behavior` being under body, not html. This commit moves it to html and makes it in Tailwind CSS format.

## Preview

https://github.com/user-attachments/assets/fdc62867-d76e-4d9b-8f08-3368c6a3a33d

