### PR TITLE
feat: Download button for Arch Linux users

### DIFF
--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -481,12 +481,11 @@ export default function DownloadPage() {
                 <FieldDescription>
                   Choose the type of download you want for Zen for Linux.
                 </FieldDescription>
-                <div>
-                <div className="flex items-center justify-center">
+                <div className="grid grid-cols-2 grid-rows-2 gap-4 mb-2">
                   <div
                     onClick={() => setSelectedLinuxDownloadType("appimage")}
                     className={ny(
-                      "select-none w-full h-full mb-2 p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
+                      "select-none w-full h-full p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
                       selectedLinuxDownloadType === "appimage"
                         ? "border-blue-400"
                         : ""
@@ -503,7 +502,7 @@ export default function DownloadPage() {
                   <div
                     onClick={() => setSelectedLinuxDownloadType("portable")}
                     className={ny(
-                      "select-none w-full h-full mb-2 ml-5 p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
+                      "select-none w-full h-full p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
                       selectedLinuxDownloadType === "portable"
                         ? "border-blue-400"
                         : ""
@@ -517,12 +516,10 @@ export default function DownloadPage() {
                       Download Zen as a ZIP file
                     </p>
                   </div>
-                  </div>
-                  <div className="flex items-center justify-center mt-2">
                   <div
                     onClick={() => changeToFlatpak()}
                     className={ny(
-                      "select-none w-full h-full mb-2 p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
+                      "select-none w-full h-full p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
                       selectedLinuxDownloadType === "flatpak"
                         ? "border-blue-400"
                         : "",
@@ -542,7 +539,7 @@ export default function DownloadPage() {
                   <div
                     onClick={() => changeToAur()}
                     className={ny(
-                      "select-none w-full h-full mb-2 ml-5 p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
+                      "select-none w-full h-full p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
                       selectedLinuxDownloadType === "aur"
                         ? "border-blue-400"
                         : "",
@@ -559,7 +556,6 @@ export default function DownloadPage() {
                       Install Zen from the Arch Linux user repository.
                     </p>
                   </div>
-                </div>
                 </div>
               </FormField>
             )}

--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -133,32 +133,44 @@ export default function DownloadPage() {
 
   const startDownload = () => {
     let releaseTarget: string;
-    if (selectedLinuxDownloadType === "flatpak") {
-      window.open(
-        "https://dl.flathub.org/repo/appstream/io.github.zen_browser.zen.flatpakref"
-      );
-      releaseTarget = "flatpak";
-    } else {
-      const platform = releaseTree[selectedPlatform.toLowerCase()];
-      let arch: string = selectedArchitecture;
-      if (selectedPlatform === "MacOS") {
-        releaseTarget = platform[arch];
-      } else {
-        releaseTarget =
-          platform[arch][
+  
+    switch (selectedLinuxDownloadType) {
+      case "flatpak":
+        window.open("https://dl.flathub.org/repo/appstream/io.github.zen_browser.zen.flatpakref");
+        releaseTarget = "flatpak";
+        break;
+  
+      case "aur":
+        window.open("https://aur.archlinux.org/packages/zen-browser-bin");
+        releaseTarget = "aur";
+        break;
+  
+      default:
+        // if itsnot 'aur' or 'flatpak'
+        const platform = releaseTree[selectedPlatform.toLowerCase()];
+        let arch: string = selectedArchitecture;
+  
+        if (selectedPlatform === "MacOS") {
+          releaseTarget = platform[arch];
+        } else {
+          releaseTarget = platform[arch][
             selectedPlatform === "Windows"
               ? (selectedWindowsDownloadType as string)
               : (selectedLinuxDownloadType as string)
           ];
-      }
-      console.log("Downloading: ");
-      console.log("platform: ", selectedPlatform);
-      console.log("compat: ", arch);
-      window.location.replace(`${BASE_URL}/${releases[releaseTarget]}`);
+        }
+  
+        console.log("Downloading: ");
+        console.log("platform: ", selectedPlatform);
+        console.log("compat: ", arch);
+        window.location.replace(`${BASE_URL}/${releases[releaseTarget]}`);
+        break;
     }
+
     setHasDownloaded(true);
     throwConfetti();
-  };
+  
+  }
 
   const continueFlow = () => {
     if (flowIndex === 0) setPlatform(selectedPlatform);
@@ -191,6 +203,12 @@ export default function DownloadPage() {
     }
   };
 
+  const changeToAur = () => {
+    if (selectedArchitecture === "specific") {
+      setSelectedLinuxDownloadType("aur");
+    }
+  };
+
   return (
     <>
       <link
@@ -209,7 +227,7 @@ export default function DownloadPage() {
         href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css"
       />
 
-      <div className="w-full overflow-hidden relative h-screen flex items-center justify-center flex-col lg:flex-row">
+      <div className="w-full overflow-hidden relative min-h-screen flex items-center justify-center flex-col lg:flex-row py-28">
         <div className="flex flex-col justify-center w-full p-10 md:p-20 lg:p-0 lg:w-1/2 2xl:w-1/3 mx-auto">
           {(hasDownloaded && (
             <div className="flex items-center justify-center flex-col">
@@ -463,6 +481,7 @@ export default function DownloadPage() {
                 <FieldDescription>
                   Choose the type of download you want for Zen for Linux.
                 </FieldDescription>
+                <div>
                 <div className="flex items-center justify-center">
                   <div
                     onClick={() => setSelectedLinuxDownloadType("appimage")}
@@ -498,10 +517,12 @@ export default function DownloadPage() {
                       Download Zen as a ZIP file
                     </p>
                   </div>
+                  </div>
+                  <div className="flex items-center justify-center mt-2">
                   <div
                     onClick={() => changeToFlatpak()}
                     className={ny(
-                      "select-none w-full h-full mb-2 ml-5 p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
+                      "select-none w-full h-full mb-2 p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
                       selectedLinuxDownloadType === "flatpak"
                         ? "border-blue-400"
                         : "",
@@ -518,6 +539,27 @@ export default function DownloadPage() {
                       Install Zen from the Flatpak repository.
                     </p>
                   </div>
+                  <div
+                    onClick={() => changeToAur()}
+                    className={ny(
+                      "select-none w-full h-full mb-2 ml-5 p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
+                      selectedLinuxDownloadType === "aur"
+                        ? "border-blue-400"
+                        : "",
+                      selectedArchitecture === "generic"
+                        ? "opacity-50 cursor-not-allowed"
+                        : ""
+                    )}
+                  >
+                    <h1 className="text-5xl my-2 opacity-40 dark:opacity-20">
+                      🧑‍💻
+                    </h1>
+                    <h1 className="text-2xl font-semibold my-2">AUR</h1>
+                    <p className="text-muted-foreground mx-auto text-center">
+                      Install Zen from the Arch Linux user repository.
+                    </p>
+                  </div>
+                </div>
                 </div>
               </FormField>
             )}

--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -141,7 +141,7 @@ export default function DownloadPage() {
         break;
   
       case "aur":
-        window.open("https://aur.archlinux.org/packages/zen-browser-bin");
+        window.open((selectedArchitecture=="specific") ? "https://aur.archlinux.org/packages/zen-browser-avx2-bin" : "https://aur.archlinux.org/packages/zen-browser-bin");
         releaseTarget = "aur";
         break;
   
@@ -204,9 +204,7 @@ export default function DownloadPage() {
   };
 
   const changeToAur = () => {
-    if (selectedArchitecture === "specific") {
-      setSelectedLinuxDownloadType("aur");
-    }
+    setSelectedLinuxDownloadType("aur");
   };
 
   return (
@@ -542,9 +540,6 @@ export default function DownloadPage() {
                       "select-none w-full h-full p-5 flex flex-col items-center rounded-lg bg-background cursor-pointer border",
                       selectedLinuxDownloadType === "aur"
                         ? "border-blue-400"
-                        : "",
-                      selectedArchitecture === "generic"
-                        ? "opacity-50 cursor-not-allowed"
                         : ""
                     )}
                   >

--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -481,7 +481,7 @@ export default function DownloadPage() {
                 <FieldDescription>
                   Choose the type of download you want for Zen for Linux.
                 </FieldDescription>
-                <div className="grid grid-cols-2 grid-rows-2 gap-4 mb-2">
+                <div className="grid grid-cols-2 grid-rows-2 gap-6 mb-2">
                   <div
                     onClick={() => setSelectedLinuxDownloadType("appimage")}
                     className={ny(


### PR DESCRIPTION
In the Discord suggestions, Pashacik said he couldn't find AUR repo and said we should add a button for it. 

- The AUR option will open the link to AUR when the user clicks download and triggers `setHasDownloaded(true); throwConfetti();`. 
I asked the Discord for the links:
Optimized - https://aur.archlinux.org/packages/zen-browser-avx2-bin
Generic - https://aur.archlinux.org/packages/zen-browser-bin

- Changed the linux "select architecture" buttons from flexbox to a 2x2 grid and added AUR as the 4th option. So it's AppImage, Portable, Flatpak and AUR. 

- Added vertical padding and changed `h-screen` to `min-h-screen` so the text didn't go behind the navbar due to the extra height gained by an extra row of buttons. 

### Preview

<img width="1181" alt="Screenshot 2024-08-31 at 10 15 33 PM" src="https://github.com/user-attachments/assets/ce145d0e-86e0-4c58-ba5f-2dbd573129b4">


