### PR TITLE
fix:Ensure theme changes on single click in ModeToggle

### DIFF
--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { useEffect, useState } from "react";
 import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
 import { useTheme } from "next-themes";
@@ -7,24 +6,20 @@ import { Button } from "./ui/button";
 
 export function ModeToggle() {
 	const { theme, setTheme } = useTheme();
+	const [currentTheme, setCurrentTheme] = useState<string | undefined>(theme);
+
+	useEffect(() => {
+		setCurrentTheme(theme);
+	}, [theme]);
 
 	const toggleTheme = () => {
-		switch (theme) {
-			case "system":
-				setTheme("dark");
-				break;
-			case "dark":
-				setTheme("light");
-				break;
-			case "light":
-				setTheme("system");
-				break;
-		}
+		const newTheme = currentTheme === "light" ? "dark" : "light";
+		setTheme(newTheme);
+		setCurrentTheme(newTheme);
 	};
 
 	// prevent hydration error
 	const [mounted, setMounted] = useState(false);
-
 	useEffect(() => {
 		setMounted(true);
 	}, []);
@@ -35,15 +30,11 @@ export function ModeToggle() {
 
 	return (
 		<Button variant="ghost" size="icon" onClick={toggleTheme}>
-			<MoonIcon
-				className={`${theme === "system" ? "visible" : "hidden"} h-[1.2rem] w-[1.2rem]`}
-			/>
-			<SunIcon
-				className={`${theme === "light" ? "visible" : "hidden"} h-[1.2rem] w-[1.2rem]`}
-			/>
-			<MoonIcon
-				className={`${theme === "dark" ? "visible" : "hidden"} h-[1.2rem] w-[1.2rem]`}
-			/>
+			{currentTheme === "light" ? (
+				<SunIcon className="h-[1.2rem] w-[1.2rem]" />
+			) : (
+				<MoonIcon className="h-[1.2rem] w-[1.2rem]" />
+			)}
 			<span className="sr-only">Toggle theme</span>
 		</Button>
 	);


### PR DESCRIPTION
fix: Ensure theme changes on single click in ModeToggle

- Simplify theme toggle to switch between light and dark
- Introduce local state for immediate UI updates
- Update icon based on current theme state
- Remove circular theme rotation to ensure visible change on each click