### PR TITLE
chore: git ignore IDE config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# various IDEs and backup files
+.vscode/
+.idea/
+**/*~
+
 # dependencies
 /node_modules
 /.pnp


### PR DESCRIPTION
# Motivation

I'm using WebStorm, and my editor was notifying me about committing config files while I was "working" on a style fix. I think it's best practice not to commit IDE and backup files, so I added those to the `.gitignore` list.