### PR TITLE
style: fix text selection color in Firefox dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,95 +3,106 @@
 @tailwind utilities;
 
 @layer base {
-   :root {
-      --background: 0 0% 100%;
-      --foreground: 0 0% 3.9%;
+	:root {
+		--background: 0 0% 100%;
+		--foreground: 0 0% 3.9%;
 
-      --card: 0 0% 100%;
-      --card-foreground: 0 0% 3.9%;
+		--card: 0 0% 100%;
+		--card-foreground: 0 0% 3.9%;
 
-      --popover: 0 0% 100%;
-      --popover-foreground: 0 0% 3.9%;
+		--popover: 0 0% 100%;
+		--popover-foreground: 0 0% 3.9%;
 
-      --primary: 0 0% 9%;
-      --primary-foreground: 0 0% 98%;
+		--primary: 0 0% 9%;
+		--primary-foreground: 0 0% 98%;
 
-      --secondary: 0 0% 96.1%;
-      --secondary-foreground: 0 0% 9%;
+		--secondary: 0 0% 96.1%;
+		--secondary-foreground: 0 0% 9%;
 
-      --muted: 0 0% 96.1%;
-      --muted-foreground: 0 0% 45.1%;
+		--muted: 0 0% 96.1%;
+		--muted-foreground: 0 0% 45.1%;
 
-      --accent: 0 0% 96.1%;
-      --accent-foreground: 0 0% 9%;
+		--accent: 0 0% 96.1%;
+		--accent-foreground: 0 0% 9%;
 
-      --destructive: 0 84.2% 60.2%;
-      --destructive-foreground: 0 0% 98%;
+		--destructive: 0 84.2% 60.2%;
+		--destructive-foreground: 0 0% 98%;
 
-      --border: 0 0% 89.8%;
-      --input: 0 0% 89.8%;
-      --ring: 0 0% 3.9%;
+		--border: 0 0% 89.8%;
+		--input: 0 0% 89.8%;
+		--ring: 0 0% 3.9%;
 
-      --radius: 0.5rem;
+		--radius: 0.5rem;
 
-      /* Custom properties */
-      --navigation-height: 3.5rem;
-      --color-one: #ffbd7a;
+		/* Custom properties */
+		--navigation-height: 3.5rem;
+		--color-one: #ffbd7a;
 
-      --color-two: #fe8bbb;
-      --color-three: #9e7aff;
+		--color-two: #fe8bbb;
+		--color-three: #9e7aff;
 
-      --surface: rgb(245, 245, 245);
+		--surface: rgb(245, 245, 245);
 
-      /*
+		/*
     --color-one: #37ecba;
     --color-two: #72afd3;
     --color-three: #ff2e63;
      */
-   }
+	}
 
-   [data-theme='dark'], .dark {
-      --background: 5 5 5;
-      --foreground: 0 0% 98%;
+	[data-theme="dark"],
+	.dark {
+		--background: 5 5 5;
+		--foreground: 0 0% 98%;
 
-      --surface: rgb(23, 23, 23); 
+		--surface: rgb(23, 23, 23);
 
-      --card: 0 0% 3.9%;
-      --card-foreground: 0 0% 98%;
+		--card: 0 0% 3.9%;
+		--card-foreground: 0 0% 98%;
 
-      --popover: 0 0% 3.9%;
-      --popover-foreground: 0 0% 98%;
+		--popover: 0 0% 3.9%;
+		--popover-foreground: 0 0% 98%;
 
-      --primary: 0 0% 98%;
-      --primary-foreground: 0 0% 9%;
+		--primary: 0 0% 98%;
+		--primary-foreground: 0 0% 9%;
 
-      --secondary: 0 0% 14.9%;
-      --secondary-foreground: 0 0% 98%;
+		--secondary: 0 0% 14.9%;
+		--secondary-foreground: 0 0% 98%;
 
-      --muted: 0 0% 14.9%;
-      --muted-foreground: 0 0% 63.9%;
+		--muted: 0 0% 14.9%;
+		--muted-foreground: 0 0% 63.9%;
 
-      --accent: 0 0% 14.9%;
-      --accent-foreground: 0 0% 98%;
+		--accent: 0 0% 14.9%;
+		--accent-foreground: 0 0% 98%;
 
-      --destructive: 0 62.8% 30.6%;
-      --destructive-foreground: 0 0% 98%;
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 0 0% 98%;
 
-      --border: 0 0% 14.9%;
-      --input: 0 0% 14.9%;
-      --ring: 0 0% 83.1%;
-      --color-one: #6aa8e2;
-   }
+		--border: 0 0% 14.9%;
+		--input: 0 0% 14.9%;
+		--ring: 0 0% 83.1%;
+		--color-one: #6aa8e2;
+	}
 }
 
 @layer base {
-   html {
-      @apply scroll-smooth;
-   }
-   * {
-      @apply border-border;
-   }
-   body {
-      @apply bg-background text-foreground;
-   }
+	html {
+		@apply scroll-smooth;
+	}
+	* {
+		@apply border-border;
+	}
+	body {
+		@apply bg-background text-foreground;
+	}
+}
+
+::selection {
+	color: hsl(var(--primary-foreground));
+	background: hsl(var(--primary));
+}
+
+::-moz-selection {
+	color: hsl(var(--primary-foreground));
+	background: hsl(var(--primary));
 }


### PR DESCRIPTION
# Motivation

In Firefox dark mode, when the user selects text, it becomes hidden.

I'm not sure which style you prefer or the best way to specify the `::selection` style class in your setup, but here's a PR that uses the primary color to make the selected text more contrasting.

# Screenshots

Issue:

<img width="1536" alt="Capture d’écran 2024-09-14 à 11 55 56" src="https://github.com/user-attachments/assets/f136bbff-d26d-4c2e-9828-8e7ab14fee5d">
<img width="1536" alt="Capture d’écran 2024-09-14 à 11 56 09" src="https://github.com/user-attachments/assets/ac11d7c4-1a6a-4217-aac9-0b301fdab4da">

Suggested solution:

<img width="1536" alt="Capture d’écran 2024-09-14 à 11 58 52" src="https://github.com/user-attachments/assets/8abbbf8f-f40f-4997-8b4e-39764787d5ee">
<img width="1536" alt="Capture d’écran 2024-09-14 à 11 58 58" src="https://github.com/user-attachments/assets/def2a47d-aaac-4d59-a275-82e5a0b29c62">
