### PR TITLE
fix: Release notes header `XL` padding

### DIFF
--- a/src/app/release-notes/page.tsx
+++ b/src/app/release-notes/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 export default function ReleaseNotes() {
 	return (
 		<main className="flex min-h-screen flex-col items-center justify-start">
-			<div className="py-42 flex min-h-screen flex-col justify-center px-10 lg:px-24 xl:px-0 2xl:w-3/5">
+			<div className="py-42 flex min-h-screen flex-col justify-center px-10 lg:px-10 xl:px-10 2xl:w-3/5">
 				<h1 className="mt-48 text-4xl font-bold">Release Notes</h1>
 				<p className="mt-8 text-lg text-muted-foreground">
 					Stay up to date with the latest changes to Zen Browser! Since the{" "}


### PR DESCRIPTION
Minor tweak to the 'header' container padding when viewing at `XL` width, as it previously didn't have any before. Have also updated the `LG` value to 10 as well so the padding is more consistent across different breakpoints.

Before:
<img width="397" alt="image" src="https://github.com/user-attachments/assets/5a6d4e12-07b8-4880-b2cc-9eb46cdd14fd">

After:
<img width="447" alt="image" src="https://github.com/user-attachments/assets/964eccf7-53b5-45d2-80da-1bc65ae281cb">

Let me know what you think! ❤️ 

