### PR TITLE
Update download.tsx

### DIFF
--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -529,9 +529,6 @@ export default function DownloadPage() {
 											selectedLinuxDownloadType === "flatpak"
 												? "border-blue-400"
 												: "",
-											selectedArchitecture === "specific"
-												? "cursor-not-allowed opacity-50"
-												: "",
 										)}
 									>
 										<h1 className="my-2 text-5xl opacity-40 dark:opacity-20">


### PR DESCRIPTION
_Since_ the **offical flatpak version** is also fully available on linux, removed the prior `cross cursor icon` on `hover over` on `flatpak (Linux)`.