### PR TITLE
Clipboard copy button

### DIFF
--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -2,7 +2,6 @@
 import { useState, useEffect } from "react";
 import styled, { keyframes } from "styled-components";
 import { ny } from "@/lib/utils";
-import { Checkbox } from "./ui/checkbox";
 import { ChevronLeft, InfoIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import Particles from "./ui/particles";
@@ -14,6 +13,7 @@ const BASE_URL =
 	"https://github.com/zen-browser/desktop/releases/latest/download";
 
 import SparklesText from "./ui/sparkles-text";
+import { CopyButton } from "@/components/ui/copy-button";
 const field_enter = keyframes`
   0% {
     opacity: 0;
@@ -191,6 +191,9 @@ export default function DownloadPage() {
 		}
 	};
 
+	const linuxAppimageBashScript =
+		'bash {"<"}(curl https://updates.zen-browser.app/appimage.sh)';
+
 	return (
 		<>
 			<link
@@ -240,8 +243,12 @@ export default function DownloadPage() {
 										If you're using an AppImage, you can use the automatic
 										installer, check it out{" "}
 									</p>
-									<pre className="mt-2 rounded-md bg-background p-2 text-muted-foreground">
-										bash {"<"}(curl https://updates.zen-browser.app/appimage.sh)
+									<pre className="mt-2 flex items-center rounded-md bg-background p-2 text-muted-foreground">
+										{linuxAppimageBashScript}
+										<CopyButton
+											className="ml-3"
+											valueToCopy={linuxAppimageBashScript}
+										/>
 									</pre>
 								</div>
 							)}

--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -4,6 +4,7 @@ import styled, { keyframes } from "styled-components";
 import { ny } from "@/lib/utils";
 import { ChevronLeft, InfoIcon } from "lucide-react";
 import { Button } from "./ui/button";
+import { CopyButton } from "./ui/copy-button";
 import Particles from "./ui/particles";
 import confetti from "canvas-confetti";
 import { releases, releaseTree } from "@/lib/releases";
@@ -13,7 +14,6 @@ const BASE_URL =
 	"https://github.com/zen-browser/desktop/releases/latest/download";
 
 import SparklesText from "./ui/sparkles-text";
-import { CopyButton } from "@/components/ui/copy-button";
 const field_enter = keyframes`
   0% {
     opacity: 0;

--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -192,7 +192,7 @@ export default function DownloadPage() {
 	};
 
 	const linuxAppimageBashScript =
-		'bash {"<"}(curl https://updates.zen-browser.app/appimage.sh)';
+		'bash <(curl https://updates.zen-browser.app/appimage.sh)';
 
 	return (
 		<>

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import { Button } from "./button";
-import { CopyIcon } from "@radix-ui/react-icons";
+import { CheckIcon, CopyIcon } from "@radix-ui/react-icons";
 
 import { useClipboard } from "@/lib/hooks";
 
@@ -15,6 +15,29 @@ const CopyButton = React.forwardRef<
 >(({ className, valueToCopy, ...props }, ref) => {
 	const copyToClipboard = useClipboard(valueToCopy);
 
+	const [showSuccessIcon, setShowSuccessIcon] = React.useState(false);
+
+	const handleCopy = () => {
+		copyToClipboard();
+		setShowSuccessIcon(true);
+	};
+
+	React.useEffect(() => {
+		let timeout: ReturnType<typeof setTimeout> | null = null;
+
+		if (showSuccessIcon) {
+			timeout = setTimeout(() => {
+				setShowSuccessIcon(false);
+			}, 5000);
+		}
+
+		return () => {
+			if (timeout) {
+				clearTimeout(timeout);
+			}
+		};
+	}, [showSuccessIcon]);
+
 	return (
 		<>
 			<Button
@@ -22,10 +45,14 @@ const CopyButton = React.forwardRef<
 				variant={"ghost"}
 				size={"icon"}
 				className={className}
-				onClick={copyToClipboard}
+				onClick={handleCopy}
 				{...props}
 			>
-				<CopyIcon className="size-4" />
+				{showSuccessIcon ? (
+					<CheckIcon className="size-5 text-green-500" />
+				) : (
+					<CopyIcon className="size-4" />
+				)}
 			</Button>
 		</>
 	);

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { CopyIcon } from "@radix-ui/react-icons";
+
+import { useClipboard } from "@/lib/hooks";
+
+const CopyButton = React.forwardRef<
+	React.ElementRef<typeof Button>,
+	React.ComponentPropsWithoutRef<typeof Button> & {
+		valueToCopy: string;
+	}
+>(({ className, valueToCopy, ...props }, ref) => {
+	const copyToClipboard = useClipboard(valueToCopy);
+
+	return (
+		<>
+			<Button
+				ref={ref}
+				variant={"ghost"}
+				size={"icon"}
+				className={className}
+				onClick={copyToClipboard}
+				{...props}
+			>
+				<CopyIcon className="size-4" />
+			</Button>
+		</>
+	);
+});
+
+export { CopyButton };

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "./button";
 import { CopyIcon } from "@radix-ui/react-icons";
 
 import { useClipboard } from "@/lib/hooks";

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,0 +1,7 @@
+export function useClipboard(valueToCopy: string) {
+	const copyToClipboard = () => {
+		navigator.clipboard.writeText(valueToCopy);
+	};
+
+	return copyToClipboard;
+}


### PR DESCRIPTION
I suggest adding a 'Copy to Clipboard' button for scripts. Additionally, I would like to implement a toast notification upon copying, but I am unsure if there are any existing designs for it. Another enhancement I propose is adding a script for Flatpak installation similar to the one you have for AppImage installation. If you approve of these suggestions, I can implement them in this PR.

![image](https://github.com/user-attachments/assets/8fd25f32-726c-4f0c-a492-efe8ea3340a9)

After copy button click check icon is shown for 3 sec

![image](https://github.com/user-attachments/assets/dfa20868-f9ee-4aa1-9bf9-f60d41d11e7b)

