### PR TITLE
fix: gradient text outline bugged in firefox

### DIFF
--- a/src/components/cool-header-text.tsx
+++ b/src/components/cool-header-text.tsx
@@ -23,7 +23,7 @@ const TextTitle = styled.h1`
 export default function CoolHeaderText() {
 	return (
 		<>
-			<div className="relative mb-3 mt-5 -translate-y-4 animate-fade-in text-balance bg-gradient-to-br from-black from-30% to-black/40 bg-clip-text py-6 text-5xl font-extrabold font-semibold leading-none tracking-tighter text-transparent opacity-0 [--animation-delay:200ms] dark:from-white dark:to-white/40 sm:text-6xl md:text-7xl lg:text-8xl">
+			<div className="relative mb-3 mt-5 -translate-y-4 animate-fade-in text-balance bg-gradient-to-br from-30% to-black/40 bg-clip-text py-6 text-5xl font-extrabold font-semibold leading-none tracking-tighter text-transparent opacity-0 [--animation-delay:200ms] dark:from-white dark:to-white/40 sm:text-6xl md:text-7xl lg:text-8xl">
 				<TextTitle>
 					Beautiful. Fast. Private.
 					<br />


### PR DESCRIPTION
This could be some firefox's aa bug, however this bugged outline is caused by [color stop](https://tailwindcss.com/docs/gradient-color-stops) .