### PR TITLE
fix: download option for unsupported OS

### DIFF
--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -579,7 +579,7 @@ export default function DownloadPage() {
 							</Button>
 							<Button
 								onClick={() => continueFlow()}
-								disabled={selectedPlatform === null}
+								disabled={selectedPlatform === ""}
 							>
 								{(flowIndex === 1 && platform === "MacOS") || flowIndex === 2
 									? "Download 🥳"


### PR DESCRIPTION
In the case of an unsupported OS, if you don't select an OS version, you will be given a download option that doesn't work.

https://github.com/zen-browser/www/issues/210#issuecomment-2395042406 