### PR TITLE
fix: download option for unsupported OS

### DIFF
--- a/src/components/download.tsx
+++ b/src/components/download.tsx
@@ -579,12 +579,21 @@ export default function DownloadPage() {
 							</Button>
 							<Button
 								onClick={() => continueFlow()}
-								disabled={selectedPlatform === null}
+								disabled={selectedPlatform === ""}
 							>
 								{(flowIndex === 1 && platform === "MacOS") || flowIndex === 2
 									? "Download 🥳"
 									: "Continue"}
 							</Button>
+						</div>
+					)}
+					{selectedPlatform === "" && (
+						<div className="mt-5 flex items-center">
+							<InfoCircledIcon className="mr-2 size-4" />
+							<p className="text-muted-foreground">
+								Unfortunately, Zen Browser is not available for your platform at
+								this time.
+							</p>
 						</div>
 					)}
 					{(platform === "Linux" || platform === "Windows") &&


### PR DESCRIPTION
In the case of an unsupported OS, if you don't select an OS version, you will be given a download option that doesn't work.

<img width="1437" alt="Screenshot 2024-10-05 at 9 37 54 PM" src="https://github.com/user-attachments/assets/4d1ba74e-e430-41ca-a887-8341fc9f2e41">

https://github.com/zen-browser/www/issues/210#issue-2564650745