### PR TITLE
fix: margin between socials and text

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -12,8 +12,8 @@ import { Button } from "./ui/button";
 export default function Footer() {
 	return (
 		<div className="border-grey align-center mt-10 flex w-full flex-col border-t px-10 py-10 font-medium md:px-0">
-			<div className="mx-auto flex w-full justify-between border-b px-10 pb-10 pt-10 lg:!w-2/3 lg:px-0">
-				<div className="mr-4 flex flex-col">
+			<div className="mx-auto flex w-full justify-between gap-[20px] border-b px-10 pb-10 pt-10 lg:!w-2/3 lg:px-0">
+				<div className="flex flex-col">
 					<Logo />
 					<div className="mt-auto">
 						<h1 className="text-2xl font-bold opacity-80">Zen Browser</h1>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
 import Logo from "./logo";
 import TextReveal from "./ui/text-reveal";
-import { DiscordLogoIcon, GitHubLogoIcon, TwitterLogoIcon } from "@radix-ui/react-icons";
+import {
+	DiscordLogoIcon,
+	GitHubLogoIcon,
+	TwitterLogoIcon,
+} from "@radix-ui/react-icons";
 import { MastodonLogo } from "./icons/mastodon";
 import { Button } from "./ui/button";
 
@@ -9,7 +13,7 @@ export default function Footer() {
 	return (
 		<div className="border-grey align-center mt-10 flex w-full flex-col border-t px-10 py-10 font-medium md:px-0">
 			<div className="mx-auto flex w-full justify-between border-b px-10 pb-10 pt-10 lg:!w-2/3 lg:px-0">
-				<div className="flex flex-col">
+				<div className="mr-4 flex flex-col">
 					<Logo />
 					<div className="mt-auto">
 						<h1 className="text-2xl font-bold opacity-80">Zen Browser</h1>


### PR DESCRIPTION
There is no gap between the social icons and the text.

Screenshot of Issue:
<img width="274" alt="Screenshot 2024-10-07 at 8 51 05 PM" src="https://github.com/user-attachments/assets/8ba414a7-ea32-4ed4-a252-d26c8f8fbf0c">

 If this lack of spacing was not intentional, this pull request will resolve it by adding the necessary gap.

Screenshot of Fix :
<img width="254" alt="Screenshot 2024-10-07 at 8 51 27 PM" src="https://github.com/user-attachments/assets/bd964c2c-de3f-4e3f-a50f-91b0363bb36d">

Additional Comments: If the lack of spacing was intentional, feel free to disregard this pull request. 