### PR TITLE
Capitalized Zen in Navbar

### DIFF
--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -16,7 +16,7 @@ export default function Logo({ withText, ...props }: any) {
 					withText && "mr-2",
 				)}
 			/>
-			{withText && <span className="ml-2 text-2xl font-bold">zen</span>}
+			{withText && <span className="ml-2 text-2xl font-bold">Zen</span>}
 		</div>
 	);
 }


### PR DESCRIPTION
Capitalizing 'Zen' in the navbar is more consistent with other parts of the website and feels better.