### PR TITLE
Replace mouse down with link and added version and download/uninstall button

### DIFF
--- a/src/components/theme-card.tsx
+++ b/src/components/theme-card.tsx
@@ -70,8 +70,14 @@ export default function ThemeCard({
 					)}
 				</div>
 				<div className="mt-2 flex">
+					{theme.version && (
+						<span className="text-md text-muted-foreground">
+							v{theme.version}
+						</span>
+					)}
 					{theme.homepage && (
 						<>
+							<span className="text-md mx-2 text-muted-foreground">{"·"}</span>
 							<a
 								href={theme.homepage}
 								className="text-md z-10 text-blue-500"
@@ -80,23 +86,19 @@ export default function ThemeCard({
 							>
 								Homepage
 							</a>
-							<span className="text-md mx-2 text-muted-foreground">{"·"}</span>
 						</>
 					)}
-					<a
-						href={getThemeAuthorLink(theme)}
-						className="text-md z-10 text-blue-500"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Author
-					</a>
-					{theme.version && (
+					{theme.author && (
 						<>
 							<span className="text-md mx-2 text-muted-foreground">{"·"}</span>
-							<span className="text-md text-muted-foreground">
-								v{theme.version}
-							</span>
+							<a
+								href={getThemeAuthorLink(theme)}
+								className="text-md z-10 text-blue-500"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Author
+							</a>
 						</>
 					)}
 				</div>

--- a/src/components/theme-card.tsx
+++ b/src/components/theme-card.tsx
@@ -1,9 +1,10 @@
 import { getThemeAuthorLink, ZenTheme } from "@/lib/themes";
 import styled from "styled-components";
-import { TagIcon } from "lucide-react";
+import { DownloadIcon, TagIcon, TrashIcon } from "lucide-react";
 
 import { ny } from "@/lib/utils";
 import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
 
 const ThemeCardWrapper = styled.div``;
 
@@ -19,17 +20,12 @@ export default function ThemeCard({
 
 	return (
 		<ThemeCardWrapper
-			onMouseDown={(event) => {
-				if (event.button !== 0 && event.button !== 1) return;
-				if (event.target instanceof HTMLAnchorElement) return;
-				window.open(`/themes/${theme.id}`, event.button === 1 ? "_blank" : "_self");
-			}}
 			className={ny(
-				"flex w-full cursor-pointer select-none flex-col justify-start rounded-xl border-2 border-[transparent] bg-surface transition-all transition-shadow duration-200 hover:border-[rgba(0,0,0,.5)] hover:shadow-lg dark:bg-[#121212] dark:hover:border-[#333]",
+				"relative flex w-full select-none flex-col justify-start rounded-xl border-2 bg-surface transition-colors duration-200 hover:shadow-lg dark:bg-[#121212]",
 				className,
 			)}
 		>
-      <div className="relative m-2 mb-0 hidden aspect-[1.85/1] h-48 overflow-hidden rounded-xl border-2 border-[rgba(0,0,0,.5)] object-cover shadow dark:border-[#333] lg:block lg:h-auto">
+			<div className="relative m-2 mb-0 aspect-[1.85/1] h-48 overflow-hidden rounded-xl border-2 object-cover shadow dark:border-[#333] lg:h-auto">
 				<img
 					src={theme.image}
 					alt={theme.name}
@@ -37,11 +33,29 @@ export default function ThemeCard({
 				/>
 			</div>
 			<div className="w-full p-5">
-				<h2 className="overflow-ellipsis text-start text-xl font-bold">
-					{theme.name.substring(0, maxNameLen).trim() +
-						(theme.name.length > maxNameLen ? "..." : "")}
-				</h2>
-				<div className="flex flex-wrap gap-2">
+				<div className="flex w-full items-center justify-between">
+					<h2 className="overflow-ellipsis text-start text-xl font-bold">
+						{theme.name.substring(0, maxNameLen).trim() +
+							(theme.name.length > maxNameLen ? "..." : "")}
+					</h2>
+					<div className="z-10 aspect-square h-10 w-10">
+						<Button
+							className="hidden h-full w-full !rounded-lg bg-secondary p-0 text-secondary-foreground shadow-sm hover:bg-primary-foreground"
+							id="install-theme"
+							zen-theme-id={theme.id}
+						>
+							<DownloadIcon className="h-5 w-5" />
+						</Button>
+						<Button
+							className="hidden h-full w-full !rounded-lg bg-secondary p-0 text-secondary-foreground shadow-sm hover:bg-red-500"
+							id="install-theme-uninstall"
+							zen-theme-id={theme.id}
+						>
+							<TrashIcon className="h-5 w-5" />
+						</Button>
+					</div>
+				</div>
+				<div className="mr-10 flex flex-wrap gap-2">
 					{theme.tags?.length ? (
 						theme.tags.map((tag) => (
 							<Badge key={tag} variant="secondary">
@@ -60,7 +74,7 @@ export default function ThemeCard({
 						<>
 							<a
 								href={theme.homepage}
-								className="text-md text-blue-500"
+								className="text-md z-10 text-blue-500"
 								target="_blank"
 								rel="noopener noreferrer"
 							>
@@ -71,18 +85,29 @@ export default function ThemeCard({
 					)}
 					<a
 						href={getThemeAuthorLink(theme)}
-						className="text-md text-blue-500"
+						className="text-md z-10 text-blue-500"
 						target="_blank"
 						rel="noopener noreferrer"
 					>
 						Author
 					</a>
+					{theme.version && (
+						<>
+							<span className="text-md mx-2 text-muted-foreground">{"·"}</span>
+							<span className="text-md text-muted-foreground">
+								v{theme.version}
+							</span>
+						</>
+					)}
 				</div>
 				<p className="text-md mt-2 overflow-ellipsis text-start text-muted-foreground">
 					{theme.description.substring(0, maxDescLen).trim() +
 						(theme.description.length > maxDescLen ? "..." : "")}
 				</p>
 			</div>
+			<a href={`/mods/${theme.id}`} className="absolute inset-0 h-full w-full">
+				<span className="sr-only">{`Link to ${theme.name} mod details`}</span>
+			</a>
 		</ThemeCardWrapper>
 	);
 }

--- a/src/components/theme-card.tsx
+++ b/src/components/theme-card.tsx
@@ -21,7 +21,7 @@ export default function ThemeCard({
 	return (
 		<ThemeCardWrapper
 			className={ny(
-				"relative flex w-full select-none flex-col justify-start rounded-xl border-2 bg-surface transition-colors duration-200 hover:shadow-lg dark:bg-[#121212]",
+				"relative flex w-full select-none flex-col justify-start rounded-xl border-2 border-[transparent] bg-surface transition-colors duration-200 hover:border-[rgba(0,0,0,.5)] hover:shadow-lg dark:bg-[#121212] dark:hover:border-[#333]",
 				className,
 			)}
 		>

--- a/src/components/theme-card.tsx
+++ b/src/components/theme-card.tsx
@@ -25,7 +25,7 @@ export default function ThemeCard({
 				className,
 			)}
 		>
-			<div className="relative m-2 mb-0 aspect-[1.85/1] h-48 overflow-hidden rounded-xl border-2 object-cover shadow dark:border-[#333] lg:h-auto">
+			<div className="relative m-2 mb-0 aspect-[1.85/1] h-48 overflow-hidden rounded-xl border-2 border-[rgba(0,0,0,.5)] object-cover shadow dark:border-[#333] lg:h-auto">
 				<img
 					src={theme.image}
 					alt={theme.name}


### PR DESCRIPTION
I have made several changes:
- Add a link with `position: absolute;` replacing `onMouseDown`.
- Added version display next to homepage and author link
- Added download and uninstall button. Users will no longer have to switch pages frequently to install mods.

I am unsure of how the visibility of `install-theme` and `install-theme-uninstall` is updated by Zen, so please let me know if this method would not work.

Other things I have considered but have not implemented:
- Update the component name to be `ModCardWrapper`
- Update the file name to be `mod-card.tsx`

I'm happy to take any suggestions into this pull request.