### PR TITLE
Refactor `theme card` to use `Next/Link` and `Card` component

### DIFF
--- a/src/components/theme-card.tsx
+++ b/src/components/theme-card.tsx
@@ -1,13 +1,11 @@
 import { getThemeAuthorLink, ZenTheme } from "@/lib/themes";
-import styled from "styled-components";
 
 import { TagIcon } from "lucide-react";
 
 import { ny } from "@/lib/utils";
 
 import { Badge } from "./ui/badge";
-
-const ThemeCardWrapper = styled.div``;
+import Link from "next/link";
 
 export default function ThemeCard({
 	theme,
@@ -20,12 +18,8 @@ export default function ThemeCard({
 	const maxDescLen = 100;
 
 	return (
-		<ThemeCardWrapper
-			onMouseDown={(e) => {
-				if (e.target instanceof HTMLAnchorElement) return;
-				if (e.button !== 0 && e.button !== 1) return;
-				window.open(`/themes/${theme.id}`, e.button === 1 ? "_blank" : "_self");
-			}}
+		<Link
+      href={`/themes/${theme.id}`}
 			className={ny(
 				"flex w-full cursor-pointer select-none flex-col justify-start rounded-xl border-2 border-[transparent] bg-surface transition-all duration-200 hover:border-[rgba(0,0,0,.5)] hover:shadow-lg dark:bg-[#121212] dark:hover:border-[#333]",
 				className,
@@ -89,6 +83,6 @@ export default function ThemeCard({
 						(theme.description.length > maxDescLen ? "..." : "")}
 				</p>
 			</div>
-		</ThemeCardWrapper>
+		</Link>
 	);
 }

--- a/src/components/theme-card.tsx
+++ b/src/components/theme-card.tsx
@@ -2,10 +2,9 @@ import { getThemeAuthorLink, ZenTheme } from "@/lib/themes";
 
 import { TagIcon } from "lucide-react";
 
-import { ny } from "@/lib/utils";
-
 import { Badge } from "./ui/badge";
 import Link from "next/link";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "./ui/card";
 
 export default function ThemeCard({
 	theme,
@@ -16,73 +15,77 @@ export default function ThemeCard({
 }) {
 	const maxNameLen = 50;
 	const maxDescLen = 100;
+  const authorLink = getThemeAuthorLink(theme);
 
 	return (
 		<Link
       href={`/themes/${theme.id}`}
-			className={ny(
-				"flex w-full cursor-pointer select-none flex-col justify-start rounded-xl border-2 border-[transparent] bg-surface transition-all duration-200 hover:border-[rgba(0,0,0,.5)] hover:shadow-lg dark:bg-[#121212] dark:hover:border-[#333]",
-				className,
-			)}
+      className="rounded-xl"
 		>
-			<div className="relative m-2 mb-0 hidden aspect-[1.85/1] h-48 overflow-hidden rounded-xl border-2 border-[rgba(0,0,0,.5)] object-cover shadow dark:border-[#333] lg:block lg:h-auto">
-				<img
-					src={theme.image}
-					alt={theme.name}
-					className="h-full w-full object-cover"
-				/>
-			</div>
-			<div className="w-full p-5">
-				<h2 className="overflow-ellipsis text-start text-xl font-bold">
-					{theme.name.substring(0, maxNameLen).trim() +
-						(theme.name.length > maxNameLen ? "..." : "")}
-				</h2>
-				<div className="flex min-h-6 flex-wrap gap-2">
-					{theme.tags?.length ? (
-						theme.tags.map((tag) => (
-							<Badge key={tag} variant="secondary">
-								<TagIcon className="mr-1 h-3 w-3" />
-								{tag}
-							</Badge>
-						))
-					) : (
-						<span className="self-center text-xs italic text-gray-500">
-							No tags available
-						</span>
-					)}
-				</div>
-				<div className="mt-2 flex">
-					{theme.homepage && (
-						<>
-							<object>
-								<a
-									href={theme.homepage}
-									className="text-md text-blue-500"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									Homepage
-								</a>
-							</object>
-							<span className="text-md mx-2 text-muted-foreground">{"·"}</span>
-						</>
-					)}
-					<object>
+			<Card className="select-none h-full flex-col justify-between rounded-xl border-2 border-[transparent] bg-surface transition-all duration-200 hover:border-[rgba(0,0,0,.5)] hover:shadow-lg dark:bg-[#121212] dark:hover:border-[#333]">
+			  <div className="relative m-2 mb-0 hidden aspect-[1.85/1] h-48 overflow-hidden rounded-xl border-2 border-[rgba(0,0,0,.5)] object-cover shadow dark:border-[#333] lg:block lg:h-auto">
+  				<img
+  					src={theme.image}
+  					alt={theme.name}
+  					className="h-full w-full object-cover"
+  				/>
+  			</div>
+  			<div className="w-full p-5">
+  				<CardHeader>
+  				  <CardTitle className="overflow-ellipsis text-start text-xl font-bold">
+    					{theme.name.substring(0, maxNameLen).trim() +
+    						(theme.name.length > maxNameLen ? "..." : "")}
+    				</CardTitle>
+    				<div className="flex min-h-6 flex-wrap gap-2">
+    					{theme.tags?.length ? (
+    						theme.tags.map((tag) => (
+    							<Badge key={tag} variant="secondary">
+    								<TagIcon className="mr-1 h-3 w-3" />
+    								{tag}
+    							</Badge>
+    						))
+    					) : (
+    						<span className="self-center text-xs italic text-gray-500">
+    							No tags available
+    						</span>
+    					)}
+    				</div>
+  				</CardHeader>
+          <CardContent>
+  				  <p className="text-md mt-2 overflow-ellipsis text-start text-muted-foreground">
+    					{theme.description.substring(0, maxDescLen).trim() +
+    						(theme.description.length > maxDescLen ? "..." : "")}
+    				</p>
+  				</CardContent>
+  				<CardFooter className="mt-2 flex">
+          {theme.homepage && (
 						<a
-							href={getThemeAuthorLink(theme)}
+							href={theme.homepage}
 							className="text-md text-blue-500"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={(e) => e.stopPropagation()}
+						>
+							Homepage
+						</a>
+					)}
+					{theme.homepage && authorLink && (
+						<span className="text-md mx-2 text-muted-foreground">·</span>
+					)}
+					{authorLink && (
+						<a
+							href={authorLink}
+							className="text-md text-blue-500"
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={(e) => e.stopPropagation()}
 						>
 							Author
 						</a>
-					</object>
-				</div>
-				<p className="text-md mt-2 overflow-ellipsis text-start text-muted-foreground">
-					{theme.description.substring(0, maxDescLen).trim() +
-						(theme.description.length > maxDescLen ? "..." : "")}
-				</p>
-			</div>
+					)}
+  				</CardFooter>
+  			</div>
+			</Card>
 		</Link>
 	);
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { ny } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={ny(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={ny("flex flex-col space-y-1.5", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={ny("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={ny("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={ny("", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={ny("flex items-center", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
- Refactored `theme card` to:
  - Use `Next/Link` for better accessibility
  - Use the shadcn `Card` component