### PR TITLE
Theme toggle improvements

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
 		windows: {
 			url: "https://zen-browser.app/download",
 		},
-	}
+	},
 };
 
 export default async function RootLayout({
@@ -55,7 +55,12 @@ export default async function RootLayout({
 				/>
 			</head>
 			<body className={inter.className}>
-				<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+				<ThemeProvider
+					attribute="class"
+					defaultTheme="system"
+					enableSystem
+					disableTransitionOnChange
+				>
 					<StyledComponentsRegistry>
 						<div className="mt-5">
 							{children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,7 +55,7 @@ export default async function RootLayout({
 				/>
 			</head>
 			<body className={inter.className}>
-				<ThemeProvider attribute="class" defaultTheme="dark">
+				<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
 					<StyledComponentsRegistry>
 						<div className="mt-5">
 							{children}

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,44 +1,21 @@
 "use client";
-import { useEffect, useState } from "react";
-import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
+
 import { useTheme } from "next-themes";
+import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
 import { Button } from "./ui/button";
 
 export function ModeToggle() {
-	const { setTheme, theme } = useTheme();
-	const [mounted, setMounted] = useState(false);
-
-	useEffect(() => {
-		setMounted(true);
-		const savedTheme = localStorage.getItem("theme");
-		if (savedTheme) {
-			setTheme(savedTheme);
-		} else {
-			const prefersDark = window.matchMedia(
-				"(prefers-color-scheme: dark)",
-			).matches;
-			setTheme(prefersDark ? "dark" : "light");
-		}
-	}, [setTheme]);
+	const { setTheme, resolvedTheme } = useTheme();
 
 	const toggleTheme = () => {
-		const newTheme = theme === "light" ? "dark" : "light";
+		const newTheme = resolvedTheme === "light" ? "dark" : "light";
 		setTheme(newTheme);
-		localStorage.setItem("theme", newTheme);
 	};
-
-	if (!mounted) {
-		return null;
-	}
 
 	return (
 		<Button variant="ghost" size="icon" onClick={toggleTheme}>
-			{theme === "light" ? (
-				<SunIcon className="h-[1.2rem] w-[1.2rem]" />
-			) : (
-				<MoonIcon className="h-[1.2rem] w-[1.2rem]" />
-			)}
-			<span className="sr-only">Toggle theme</span>
+			<SunIcon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+			<MoonIcon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
 		</Button>
 	);
 }


### PR DESCRIPTION
## Description

Fix #265 

- Simplify the theme toggle logic (by removing the use of `mounted` & copied from [shadcn/ui](https://github.com/shadcn-ui/ui/blob/3259fb7ca165b0ae11124257a20b71001049ecca/apps/www/components/mode-toggle.tsx)).
- Follow the system color preference until the user interacts with the toggle.
- Fix the navigation items flashing when toggling the theme by disabling the transition.

https://github.com/user-attachments/assets/60572f0b-bedb-4c60-afad-706a52a9a4b7

## Demo

https://github.com/user-attachments/assets/0b6263f3-5162-4395-a372-5c330bdd38d0
