### PR TITLE
Fix screen flashes when the page loads in dark theme

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import StyledComponentsRegistry from "@/lib/styled-components-registry";
 import Footer from "@/components/footer";
 import { Navigation } from "@/components/navigation";
+import { ny } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -54,7 +55,7 @@ export default async function RootLayout({
 					href="https://www.zen-browser.app/feed.xml"
 				/>
 			</head>
-			<body className={inter.className}>
+			<body className={ny("bg-background", inter.className)}>
 				<ThemeProvider
 					attribute="class"
 					defaultTheme="system"


### PR DESCRIPTION
## Description

This PR fixes a minor UI bug that caused a flash when the theme was set to 'dark' (or when the system theme was in dark mode) because the body didn't have a background set.

https://github.com/user-attachments/assets/66fbd084-ff45-4a90-b006-0fe36db56932

## Demo

https://github.com/user-attachments/assets/29f76503-fb76-4f05-9209-1e5dd0881aed

