### PR TITLE
Added a go back link that would keep previous search params

### DIFF
--- a/src/components/go-back.tsx
+++ b/src/components/go-back.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { ChevronLeft } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export const GoBack = () => {
+	const [link, setLink] = useState("/mods");
+
+	useEffect(() => {
+		const referrer = document.referrer;
+		if (referrer) {
+			try {
+				const prevUrl = new URL(referrer);
+				if (prevUrl.pathname === "/mods") {
+					setLink(prevUrl.href);
+				}
+			} catch (e) {
+				// ignore
+			}
+		}
+	}, []);
+
+	return (
+		<a className="flex cursor-pointer items-center opacity-70" href={link}>
+			<ChevronLeft className="mr-1 h-4 w-4" />
+			<h3 className="text-md">Go back</h3>
+		</a>
+	);
+};

--- a/src/components/marketplace.tsx
+++ b/src/components/marketplace.tsx
@@ -184,7 +184,6 @@ function MarketplacePage({ themes }: { themes: ZenTheme[] }) {
 										<PaginationLink
 											href={`/mods?${createSearchParams(searchTerm, selectedTags, limit, sortBy, pageIndex)}`}
 											aria-current={currentPage === pageIndex}
-											aria-disabled={currentPage === pageIndex}
 											className={ny(
 												currentPage === pageIndex
 													? "border-outline border"
@@ -210,7 +209,6 @@ function MarketplacePage({ themes }: { themes: ZenTheme[] }) {
 											<PaginationLink
 												href={`/mods?${createSearchParams(searchTerm, selectedTags, limit, sortBy, totalPages)}`}
 												aria-current={currentPage === totalPages}
-												aria-disabled={currentPage === totalPages}
 												className={ny(
 													currentPage === totalPages
 														? "border-outline border"

--- a/src/components/marketplace.tsx
+++ b/src/components/marketplace.tsx
@@ -184,6 +184,7 @@ function MarketplacePage({ themes }: { themes: ZenTheme[] }) {
 										<PaginationLink
 											href={`/mods?${createSearchParams(searchTerm, selectedTags, limit, sortBy, pageIndex)}`}
 											aria-current={currentPage === pageIndex}
+											aria-disabled={currentPage === pageIndex}
 											className={ny(
 												currentPage === pageIndex
 													? "border-outline border"
@@ -209,6 +210,7 @@ function MarketplacePage({ themes }: { themes: ZenTheme[] }) {
 											<PaginationLink
 												href={`/mods?${createSearchParams(searchTerm, selectedTags, limit, sortBy, totalPages)}`}
 												aria-current={currentPage === totalPages}
+												aria-disabled={currentPage === totalPages}
 												className={ny(
 													currentPage === totalPages
 														? "border-outline border"

--- a/src/components/theme-page.tsx
+++ b/src/components/theme-page.tsx
@@ -6,7 +6,8 @@ import {
 import { Button } from "./ui/button";
 import Markdown from "react-markdown";
 import "../app/privacy-policy/markdown.css";
-import { ChevronLeft, LoaderCircleIcon } from "lucide-react";
+import { LoaderCircleIcon } from "lucide-react";
+import { GoBack } from "./go-back";
 
 export default async function ThemePage({ themeID }: { themeID: string }) {
 	const theme = await getThemeFromId(themeID);
@@ -20,13 +21,7 @@ export default async function ThemePage({ themeID }: { themeID: string }) {
 		<div className="relative mx-auto mt-24 flex flex-col items-start lg:mt-56 lg:flex-row">
 			<div className="w-md relative mx-auto mr-5 flex h-full w-full flex-col rounded-lg border bg-surface p-5 shadow md:mx-0 md:max-w-sm lg:sticky lg:top-0">
 				<div className="mb-2 flex w-full items-center justify-between">
-					<a
-						className="flex cursor-pointer items-center opacity-70"
-						href="/mods"
-					>
-						<ChevronLeft className="mr-1 h-4 w-4" />
-						<h3 className="text-md">Go back</h3>
-					</a>
+					<GoBack />
 					{theme.homepage && (
 						<a
 							href={theme.homepage}


### PR DESCRIPTION
This will allow visitors to go back to the previous page by clicking on the "go back" link.
Previously, the link always sent users to /mods page which would reset all of their filtering, sorting and the page count.