### PR TITLE
fix (Mods): update pagination logic

### DIFF
--- a/src/components/marketplace.tsx
+++ b/src/components/marketplace.tsx
@@ -67,16 +67,22 @@ function MarketplacePage({ themes }: { themes: ZenTheme[] }) {
 
 	// Handle limit change
 	const handleLimitChange = (limit: string) => {
+		const newLimit = Number.parseInt(limit);
+		const newTotalPages =
+			Math.ceil(filteredAndSortedThemes.length / newLimit) || 1;
+		const newCurrentPage = Math.min(currentPage, newTotalPages);
+
 		router.replace(
 			`/mods?${createSearchParams(
 				searchTerm,
 				selectedTags,
-				Number.parseInt(limit),
+				newLimit,
 				sortBy,
 				currentPage,
 			)}`,
 		);
 		setLimit(Number.parseInt(limit));
+		setCurrentPage(newCurrentPage);
 	};
 
 	// Handle sort by change


### PR DESCRIPTION
Fixes error displayed when changing "Show 12 Mods" to "Show 36 Mods" while on the last page on the Mods page.

Currently, an page is displayed with the following error:

```
Application error: a client-side exception has occurred (see the browser console for more information).
```

**Logs**
```
RangeError: invalid array length
    NextJS 10
```