### PR TITLE
Add Sorting Options for Mods by Newest and Oldest

### DIFF
--- a/src/components/themes-search.tsx
+++ b/src/components/themes-search.tsx
@@ -32,7 +32,7 @@ export default function ThemesSearch({
 	handleLimitChange: (value: string) => void;
 	allTags: string[];
 }) {
-	const sortOptions = ["name", "createdAt", "updatedAt"];
+	const sortOptions = ["name", "newest", "oldest", "updatedAt"];
 	const limitOptions = [12, 24, 36];
 	return (
 		<>
@@ -74,8 +74,9 @@ export default function ThemesSearch({
 					</SelectTrigger>
 					<SelectContent>
 						<SelectItem value="name">Alphabetical</SelectItem>
-						<SelectItem value="createdAt">Created Date</SelectItem>
-						<SelectItem value="updatedAt">Updated Date</SelectItem>
+						<SelectItem value="newest">Newest</SelectItem>
+						<SelectItem value="oldest">Oldest</SelectItem>
+						<SelectItem value="updatedAt">Recently Updated</SelectItem>
 					</SelectContent>
 				</Select>
 				<Select

--- a/src/lib/mods.ts
+++ b/src/lib/mods.ts
@@ -163,10 +163,12 @@ export function getThemesFromSearch(
 		// Sort by selected sort method
 		if (sortBy === "name") {
 			return a.name.localeCompare(b.name);
-		} else if (sortBy === "createdAt") {
+		} else if (sortBy === "newest") {
+			return b.createdAt.getTime() - a.createdAt.getTime(); // Newest first
+		} else if (sortBy === "oldest") {
 			return a.createdAt.getTime() - b.createdAt.getTime(); // Oldest first
 		} else if (sortBy === "updatedAt") {
-			return b.updatedAt.getTime() - a.updatedAt.getTime(); // Newest first
+			return b.updatedAt.getTime() - a.updatedAt.getTime(); // Recently updated first
 		}
 
 		return 0; // Default to no sorting if sortBy is unrecognized


### PR DESCRIPTION
Added sorting options to show the newest and oldest mods. Right now, you have to select "Created Date" and scroll all the way to the end to see new mods. This makes it quicker to find them right at the top.