### PR TITLE
Fix: preserve scroll on /mods path

### DIFF
--- a/src/app/mods/[theme]/page.tsx
+++ b/src/app/mods/[theme]/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata(
 
 export async function generateStaticParams() {
 	const themes = await getAllThemes();
-	console.log(themes);
+
 	return themes.map((theme) => ({
 		theme: theme.id,
 	}));

--- a/src/app/whatsnew/page.tsx
+++ b/src/app/whatsnew/page.tsx
@@ -1,17 +1,20 @@
 "use client";
-import React from "react";
+import { useEffect } from "react";
 import { releaseNotes } from "@/lib/release-notes";
+import { useRouter } from "next/navigation";
 
 export default function ReleaseNotePage() {
-	React.useEffect(() => {
+	const router = useRouter();
+
+	useEffect(() => {
 		const searchParams = new URLSearchParams(window.location.search);
 		const version = searchParams.get("v");
 		if (version === "latest") {
-			return window.location.replace(
+			return router.replace(
 				`/release-notes/${releaseNotes[0].version}`,
 			);
 		}
-		window.location.replace(`/release-notes#${version}`);
+		router.replace(`/release-notes#${version}`);
 	}, []);
 
 	return null;

--- a/src/components/download/download.tsx
+++ b/src/components/download/download.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { ny } from "@/lib/utils";
 import {
 	BicepsFlexedIcon,
@@ -69,6 +70,8 @@ export default function DownloadPage() {
 	}, []);
 
 	const startDownload = () => {
+		const router = useRouter();
+		
 		let releaseTarget: string;
 		if (selectedLinuxDownloadType === "flatpak") {
 			window.open(
@@ -92,7 +95,7 @@ export default function DownloadPage() {
 			console.log("platform: ", selectedPlatform);
 			console.log("compat: ", arch);
 			const baseUrl = isTwilight ? TWILIGHT_BASE_URL : BASE_URL;
-			window.location.replace(`${baseUrl}/${releases[releaseTarget]}`);
+			router.replace(`${baseUrl}/${releases[releaseTarget]}`);
 		}
 		setHasDownloaded(true);
 		throwConfetti();

--- a/src/components/go-back.tsx
+++ b/src/components/go-back.tsx
@@ -1,26 +1,36 @@
 "use client";
 import { ChevronLeft } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export const GoBack = () => {
-	const [link, setLink] = useState("/mods");
+	let referrer = "";
+	const router = useRouter();
 
 	useEffect(() => {
-		const referrer = document.referrer;
-		if (referrer) {
+		const _referrer = document.referrer;
+		if (_referrer) {
 			try {
-				const prevUrl = new URL(referrer);
+				const prevUrl = new URL(_referrer);
 				if (prevUrl.pathname === "/mods") {
-					setLink(prevUrl.href);
+					referrer = _referrer;
 				}
 			} catch (e) {
-				// ignore
+				// do nothing
 			}
 		}
 	}, []);
 
+	const goBack = () => {
+		if (referrer) {
+			router.back();
+		} else {
+			router.push("/mods");
+		}
+	}
+
 	return (
-		<a className="flex cursor-pointer items-center opacity-70" href={link}>
+		<a className="flex cursor-pointer items-center opacity-70" onClick={goBack} >
 			<ChevronLeft className="mr-1 h-4 w-4" />
 			<h3 className="text-md">Go back</h3>
 		</a>

--- a/src/components/header-marquee.tsx
+++ b/src/components/header-marquee.tsx
@@ -93,7 +93,7 @@ function ReviewCard({
 function HeaderMarquee() {
 	return (
 		<div
-			className="absolute relative mb-52 flex size-full w-full flex-col items-center justify-center overflow-hidden"
+			className="relative mb-52 flex size-full w-full flex-col items-center justify-center overflow-hidden"
 			style={{
 				transform: "translateY(-10%)",
 			}}

--- a/src/components/theme-card.tsx
+++ b/src/components/theme-card.tsx
@@ -36,7 +36,7 @@ export default function ThemeCard({
 				//   increase this number: 2
 				if (e.button !== 0 && e.button !== 1) return;
 				if (e.target instanceof HTMLAnchorElement) return;
-				router.push(`/mods/${theme.id}`);
+				document.location.href = `/mods/${theme.id}`;
 			}}
 		>
 			<div className="relative m-2 mb-0 hidden aspect-[1.85/1] h-48 overflow-hidden rounded-xl border-2 border-[rgba(0,0,0,.5)] object-cover shadow dark:border-[#333] lg:block lg:h-auto">

--- a/src/components/theme-card.tsx
+++ b/src/components/theme-card.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from "next/navigation";
+
 import { getThemeAuthorLink, ZenTheme } from "@/lib/mods";
 
 import { TagIcon } from "lucide-react";
@@ -21,19 +23,20 @@ export default function ThemeCard({
 	const maxNameLen = 50;
 	const maxDescLen = 100;
 	const authorLink = getThemeAuthorLink(theme);
+	const router = useRouter();
 
 	return (
 		<Card
-			className="h-full select-none flex-col justify-between rounded-xl border-2 border-[transparent] bg-surface transition-all duration-200 hover:border-[rgba(0,0,0,.5)] hover:shadow-lg dark:bg-[#121212] dark:hover:border-[#333]"
+			className="h-full select-none flex-col justify-between rounded-xl border-2 border-[transparent] bg-surface transition-all duration-200 hover:border-[rgba(0,0,0,.5)] hover:shadow-lg dark:bg-[#121212] dark:hover:border-[#333] cursor-pointer"
 			onMouseDown={(e) => {
 				// IMPORTANT NOTE: We do NOT use a Link component here because of how zen manages site injection.
 				//   please for the love of god, dont change this to a Link component. Please.
 				//
 				// If you had the tentation to change this to a Link component and saw this comment, please
-				//   increase this number: 1
+				//   increase this number: 2
 				if (e.button !== 0 && e.button !== 1) return;
 				if (e.target instanceof HTMLAnchorElement) return;
-				window.open(`/mods/${theme.id}`, e.button === 1 ? "_blank" : "_self");
+				router.push(`/mods/${theme.id}`);
 			}}
 		>
 			<div className="relative m-2 mb-0 hidden aspect-[1.85/1] h-48 overflow-hidden rounded-xl border-2 border-[rgba(0,0,0,.5)] object-cover shadow dark:border-[#333] lg:block lg:h-auto">


### PR DESCRIPTION
This is a duplicate of [#282](https://github.com/zen-browser/www/pull/282), but I reverted the change that prevented Zen from detecting the install button.

Changes:
 - Use Next router where possible (not on the mods path)
 - Use router.back instead of replacing the href in the mod store to prevents the user from having to scroll to whatever position they were on the page.