### PR TITLE
Fixing screen flash when using dark theme 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"lucide-react": "^0.454.0",
 				"moment": "^2.30.1",
 				"next": "14.2.10",
-				"next-themes": "^0.3.0",
+				"next-themes": "^0.4.3",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-hook-form": "^7.52.2",
@@ -15537,13 +15537,13 @@
 			}
 		},
 		"node_modules/next-themes": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
-			"integrity": "sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.3.tgz",
+			"integrity": "sha512-nG84VPkTdUHR2YeD89YchvV4I9RbiMAql3GiLEQlPvq1ioaqPaIReK+yMRdg/zgiXws620qS1rU30TiWmmG9lA==",
 			"license": "MIT",
 			"peerDependencies": {
-				"react": "^16.8 || ^17 || ^18",
-				"react-dom": "^16.8 || ^17 || ^18"
+				"react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
 			}
 		},
 		"node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"lucide-react": "^0.454.0",
 		"moment": "^2.30.1",
 		"next": "14.2.10",
-		"next-themes": "^0.3.0",
+		"next-themes": "^0.4.3",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-hook-form": "^7.52.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,6 +61,7 @@ export default async function RootLayout({
 					defaultTheme="system"
 					enableSystem
 					disableTransitionOnChange
+					scriptProps={{ "data-cfasync": "false" }}
 				>
 					<StyledComponentsRegistry>
 						<div className="flex min-h-screen flex-col">


### PR DESCRIPTION
This PR should fix the screen flash on page load when using dark theme.
Site seems to use, according to Wappalyzer, Cloudflare Rocket Loader which blocks the blocking script from next-themes. 

I'm updating package and adding a prop based on next-themes docs https://github.com/pacocoursey/next-themes#using-with-cloudflare-rocket-loader

https://github.com/user-attachments/assets/8b3c7b17-4e47-495d-a59b-c881ef13cf71

