### PR TITLE
fix(faq): Unclear sentence about HTTP-only mode

### DIFF
--- a/src/components/faq/faq.tsx
+++ b/src/components/faq/faq.tsx
@@ -54,8 +54,8 @@ export const FAQ = () => {
 						<AccordionTrigger>How secure is Zen Browser?</AccordionTrigger>
 						<AccordionContent>
 							Zen Browser is built on top of Firefox, which is known for its
-							security features. We also have additional security features like
-							HTTPS only built into Zen Browser to help keep you safe online.
+							security features. We also have additional security features like a
+							HTTPS-only mode built into Zen Browser to help keep you safe online.
 						</AccordionContent>
 					</AccordionItem>
 				</Accordion>


### PR DESCRIPTION
Very small commit but I was reading the homepage when I noticed. The way the sentence is worded makes it seem like Zen is the only browser with HTTPS support, where it is supposed to be about Zen having a HTTPS-only mode.