### PR TITLE
Feat: search description and title when searching for mods

### DIFF
--- a/src/lib/mods.ts
+++ b/src/lib/mods.ts
@@ -138,7 +138,9 @@ export function getThemesFromSearch(
 
 	// Filter themes based on query, tags, and date
 	const filteredThemes = themes.filter((theme) => {
-		const matchesQuery = theme.name.toLowerCase().includes(normalizedQuery);
+		const titleMatchesQuery = theme.name.toLowerCase().includes(normalizedQuery);
+		const descriptionMatchesQuery = theme.description.toLowerCase().includes(normalizedQuery);
+		const matchesQuery = titleMatchesQuery || descriptionMatchesQuery;
 		const matchesTag =
 			tags.length === 0 ||
 			(theme.tags && tags.some((tag) => theme.tags.includes(tag)));


### PR DESCRIPTION
This pull request makes the search bar on /mods search both title and description.