### PR TITLE
Fix(download): problems with switching platforms

### DIFF
--- a/src/components/download/download.tsx
+++ b/src/components/download/download.tsx
@@ -70,7 +70,7 @@ export default function DownloadPage() {
 
 	const startDownload = () => {
 		let releaseTarget: string;
-		if (selectedLinuxDownloadType === "flatpak") {
+		if (selectedPlatform === "Linux" && selectedLinuxDownloadType === "flatpak") {
 			window.open(
 				"https://dl.flathub.org/repo/appstream/io.github.zen_browser.zen.flatpakref",
 			);
@@ -128,6 +128,7 @@ export default function DownloadPage() {
 	const handleContinue = () => {
 		if (
 			flowIndex === 2 &&
+			selectedPlatform === "Linux" &&
 			selectedLinuxDownloadType === "flatpak" &&
 			selectedArchitecture === "specific"
 		) {
@@ -165,10 +166,10 @@ export default function DownloadPage() {
 					{(hasDownloaded && (
 						<div className="mt-20 flex flex-col items-start">
 							<DownloadedHeader />
-							{selectedLinuxDownloadType === "appimage" && (
+							{selectedPlatform === "Linux" && selectedLinuxDownloadType === "appimage" && (
 								<AppImageInstaller isTwilight={isTwilight} />
 							)}
-							{selectedLinuxDownloadType === "flatpak" && <FlatPakInstaller />}
+							{selectedPlatform === "Linux" && selectedLinuxDownloadType === "flatpak" && <FlatPakInstaller />}
 						</div>
 					)) || (
 						<>


### PR DESCRIPTION
This pull request fixes three problems on the download page when going back and switching the platform after selecting a linux download type.

1. When selecting Flatpak, then switching to Windows (optimized), the warning "Flatpak will install the Generic version" still shows up.
2. When selecting Flatpak, then switching to either Windows or MacOS, the actual file that is downloaded is the Flatpak version.
3. When selecting either Flatpak or AppImage, then switching to another platform, the page after clicking on Download contains a box explaining how to install the AppImage/Flatpak version using the command line.

All of these problems are caused by the code checking whether the selected download type is Flatpak/AppImage but not whether the current platform even is Linux.