### PR TITLE
fix: typo in release note

### DIFF
--- a/src/lib/release-notes.ts
+++ b/src/lib/release-notes.ts
@@ -1743,7 +1743,7 @@ export const releaseNotes: ReleaseNote[] = [
 			"Added support for -moz-gtk-csd-reversed-placement on Linux",
 			"Enhance workspace deactivation styles with grayscale filter for better visibility",
 			"Windows and linux ARM64 builds are now available on the github for testing!",
-			"Hidde container label when URL bar is narrow",
+			"Hide container label when URL bar is narrow",
 			"Macos ARM64 builds will now ship with PGO, performance increase!",
 		],
 		breakingChanges: [


### PR DESCRIPTION
Corrects a typo in the release notes referencing https://github.com/zen-browser/desktop/pull/3194.