### PR TITLE
feat(ui): add custom cursor

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,11 @@ import StyledComponentsRegistry from "@/lib/styled-components-registry";
 import Footer from "@/components/footer";
 import { Navigation } from "@/components/navigation";
 import { ny } from "@/lib/utils";
+import dynamic from "next/dynamic";
+
+const CustomCursor = dynamic(() => import("@/components/CustomCursor"), {
+	ssr: false
+});
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -63,6 +68,7 @@ export default async function RootLayout({
 					disableTransitionOnChange
 				>
 					<StyledComponentsRegistry>
+						<CustomCursor />
 						<div className="flex min-h-screen flex-col">
 							<Navigation />
 							<main className="flex h-full min-h-[1000px] flex-1 flex-col items-center justify-center py-4">

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -1,0 +1,96 @@
+"use client"
+import React, { useEffect } from 'react';
+import styled, { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+  * {
+    cursor: none !important;
+  }
+`;
+
+const Cursor = styled.div`
+  position: fixed;
+  width: 15px;
+  height: 15px;
+  pointer-events: none;
+  z-index: 9999;
+  left: -7px;
+  top: -7px;
+  transition: all 0.1s ease;
+  mix-blend-mode: difference;
+  isolation: isolate;
+
+  &.clickable {
+    width: 20px;
+    height: 20px;
+    left: -10px;
+    top: -10px;
+    mix-blend-mode: normal;
+  }
+`;
+
+const CursorDot = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background-color: #fff;
+  transition: background-color 0.1s ease;
+
+  .clickable & {
+    background-color: #3C82F6;
+  }
+`;
+
+const CustomCursor: React.FC = () => {
+
+  useEffect(() => {
+    const cursor = document.querySelector('.cursor') as HTMLDivElement;
+
+    const updateCursorPosition = (e: MouseEvent) => {
+      requestAnimationFrame(() => {
+        cursor.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
+      });
+    };
+
+    const handleMouseOver = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'BUTTON' || 
+          target.tagName === 'A' || 
+          target.closest('button') || 
+          target.closest('a') ||
+          target.onclick ||
+          getComputedStyle(target).cursor === 'pointer') {
+        cursor.classList.add('clickable');
+      }
+    };
+
+    const handleMouseOut = () => {
+      cursor.classList.remove('clickable');
+    };
+
+    window.addEventListener('mousemove', updateCursorPosition);
+    document.addEventListener('mouseover', handleMouseOver);
+    document.addEventListener('mouseout', handleMouseOut);
+
+    document.body.style.cursor = 'none';
+
+    return () => {
+      window.removeEventListener('mousemove', updateCursorPosition);
+      document.removeEventListener('mouseover', handleMouseOver);
+      document.removeEventListener('mouseout', handleMouseOut);
+      document.body.style.cursor = 'auto';
+    };
+  }, []);
+
+  return (
+    <>
+      <GlobalStyle />
+      <Cursor className="cursor">
+        <CursorDot />
+      </Cursor>
+    </>
+  );
+};
+
+export default CustomCursor;


### PR DESCRIPTION
Added a custom cursor to the Zen Browser website:

- This is a circular cursor whose color is the inverse of its background.

- This cursor turns blue on any clickable item for better visibility.

Here is how it will look while using the website.


---
https://github.com/user-attachments/assets/6c0f40c7-9acc-464b-b2b0-0a5d7ab95ba7


Color Inversion:
![image](https://github.com/user-attachments/assets/3e71804f-4333-4ed9-8df5-1dc034751513)

---

<small>*Just wanted to contribute something to this amazing browser 🙂* </small>