### PR TITLE
Improve Downloads Page Communication

### DIFF
--- a/src/components/download/architecture-card.tsx
+++ b/src/components/download/architecture-card.tsx
@@ -14,14 +14,14 @@ const ARCHITECTURE_DATA: Record<
 	{ label: string; icon: string; description: string }
 > = {
 	generic: {
-		label: "Generic",
+		label: "32 bit",
 		icon: "👴",
-		description: "Slow but compatible with older devices",
+		description: "Compatible with older devices (pre-2012)",
 	},
 	specific: {
-		label: "Optimized",
+		label: "64 bit",
 		icon: "🚀",
-		description: "Blazing fast and compatible with modern devices",
+		description: "Compabible with newer devices",
 	},
 };
 

--- a/src/components/download/download.tsx
+++ b/src/components/download/download.tsx
@@ -185,6 +185,10 @@ export default function DownloadPage() {
 								know which device you're using. This will only take a moment, we
 								promise.
 							</p>
+							<p className="mt-3 text-muted-foreground">
+								If you're using Winget, HomeBrew, or Arch, please visit
+								<a href="https://github.com/zen-browser/desktop" className="text-blue-400"> our GitHub repository</a> for installation instructions.
+							</p>
 							{isTwilight && (
 								<div className="mt-5 flex items-center text-yellow-500">
 									<InfoCircledIcon className="ml-2 mr-4 size-4" />

--- a/src/components/download/mac-architecture-card.tsx
+++ b/src/components/download/mac-architecture-card.tsx
@@ -17,7 +17,7 @@ const MAC_ARCHITECTURE_DATA: Record<
 		description: "For the older Macs running Intel 64-bit processors",
 	},
 	specific: {
-		label: "AArch64",
+		label: "M Series",
 		icon: "🍏",
 		description: "For the new Macs, running ARM. (AArch64)",
 	},

--- a/src/components/download/mac-architecture-card.tsx
+++ b/src/components/download/mac-architecture-card.tsx
@@ -14,12 +14,12 @@ const MAC_ARCHITECTURE_DATA: Record<
 	generic: {
 		label: "Intel",
 		icon: "x64",
-		description: "64-bit Intel architecture, for older Macs",
+		description: "For the older Macs running Intel 64-bit processors",
 	},
 	specific: {
 		label: "AArch64",
 		icon: "🍏",
-		description: "64-bit ARM architecture, for Apple's M Series Chips",
+		description: "For the new Macs, running ARM. (AArch64)",
 	},
 };
 


### PR DESCRIPTION
At the moment, the way the download communicates how to install Zen creates confusion that's avoidable.

This pull request:
1. Updates the labels for all OSes to be more clear to end users (32 bit instead of generic, M Series instead of AArch64)
2. Provides direct link to GitHub for package manager installs

Pretty short change, feel free to give any feedback on the specifics wording.