### PR TITLE
fix: mode button align-items center

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -134,7 +134,7 @@ export function Navigation() {
 							</NavigationMenuLink>
 						</NavigationMenuItem>
 					</div>
-					<div className="flex">
+					<div className="flex items-center">
 						<NavigationMenuItem>
 							<NavigationMenuTrigger>Getting Started</NavigationMenuTrigger>
 							<NavigationMenuContent>


### PR DESCRIPTION
mode toggle button is not aligned horizontally with other link buttons
just fix it
![image](https://github.com/user-attachments/assets/2cc0feb5-3521-4100-b0be-34e7dfc25fa9)


maybe, the mode toggle button move to right with version button is better
