### PR TITLE
Fix buttons not having a href property

### DIFF
--- a/src/components/Community.astro
+++ b/src/components/Community.astro
@@ -21,12 +21,10 @@ import {
     features they want. Zen focuses on privacy and customization, not on data collection.
   </Description>
   <div class="mt-6 gap-3 px-4 sm:px-0 w-full sm:gap-10 flex flex-wrap justify-center">
-    <a href="https://github.com/zen-browser">
-      <Button class:list={['px-4']}>
-        <Github class="size-4" />
-        <span>View on Github</span>
-      </Button>
-    </a>
+    <Button class:list={['px-4']} href="https://github.com/zen-browser">
+      <Github class="size-4" />
+      <span>View on Github</span>
+    </Button>
     <div class="flex items-center gap-4">
       <Check class="size-4" />
       <span>Fully Customizable</span>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -22,7 +22,7 @@ import { ArrowRight } from 'lucide-astro'
         Download
         <ArrowRight class="size-4" />
       </Button>
-      <Button>Start Exploring</Button>
+      <Button href="#features">Start Exploring</Button>
     </div>
   </div>
 </header>

--- a/src/components/HomeExtras.astro
+++ b/src/components/HomeExtras.astro
@@ -20,7 +20,7 @@ import { ArrowRight } from 'lucide-astro';
       Zen Browser is designed to be customizable. You can change every aspect of the browser to suit your needs. Literally, your imagination is the limit.
     </Description>
     <div class="flex mt-4">
-      <Button isPrimary>
+      <Button isPrimary href="/mods">
         Zen Mods
         <ArrowRight class="size-4" />
       </Button>


### PR DESCRIPTION
There were a couple of buttons that linked nowhere. Every button that looks like it should link somewhere, now actually links to the proper page/section.

One button was wrapped in `<a>` tags, but for consistency this was changed, so the button contains the `href` property.
