### PR TITLE
fix: remove empty gap between community and features section

### DIFF
--- a/src/components/Community.astro
+++ b/src/components/Community.astro
@@ -13,7 +13,7 @@ import {
 
 <section
   id="Community"
-  class="flex min-h-screen w-full flex-col items-center text-center relative"
+  class="flex w-full flex-col items-center text-center relative"
 >
   <Title>Community Driven</Title>
   <Description class="px-4 lg:px-0 lg:w-1/2">

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -13,7 +13,7 @@ import browserGlance from '../assets/browser-glance.webm';
 
 <section
   id="features"
-  class="flex w-full px-4 lg:px-12 xl:px-24 py-36 flex-col relative"
+  class="flex w-full px-4 lg:px-12 xl:px-24 py-56 flex-col relative"
 >
   <div class="flex flex-col lg:flex-row w-full items-start gap-12">
     <div id="feature-list" class="lg:w-1/3 flex flex-col gap-4">


### PR DESCRIPTION
Is full screen gap intentional ?

before:

https://github.com/user-attachments/assets/0ea08409-be63-4ae3-9f84-b669dd7920a7

after:
![image](https://github.com/user-attachments/assets/9040ba17-1c78-4741-9459-845b4f0a6208)
