### PR TITLE
fix: adjust twilight parameter to match download detection logic

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -79,7 +79,7 @@ const Reddit = icon({ prefix: "fab", iconName: "reddit" });
         <a href="/download" class="font-normal">Download</a>
         <a href="/mods" class="font-normal">Zen Mods</a>
         <a href="/release-notes" class="font-normal">Release Notes</a>
-        <a href="download?twilight" class="font-normal">Twilight</a>
+        <a href="download?twilight=true" class="font-normal">Twilight</a>
       </div>
     </div>
     <div class="flex flex-col gap-2">


### PR DESCRIPTION
Fixes #347 
-
The download page was failing to properly detect twilight release requests due to a parameter validation mismatch. The footer linked to "?twilight" while the code expected "?twilight=true", causing twilight downloads to default to stable releases.

Previous behavior:
- "?twilight" parameter without value resulted in stable release download

New behavior:
- Changed footer link to use "?twilight=true" to match existing validation in the download page

<img width="941" alt="image" src="https://github.com/user-attachments/assets/ba6649e5-a59f-4de7-b631-187a5bfa8aad" />


