### PR TITLE
feat(seo): update page titles for website

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,7 +5,7 @@ import Title from '../components/Title.astro'
 import Layout from '../layouts/Layout.astro'
 ---
 
-<Layout title="Welcome to Zen">
+<Layout title="About - Zen Browser">
   <main class="min-h-screen h-screen relative flex flex-col my-52 justify-center items-center">
     <div class="text-center p-4 mb-24 lg:w-1/2">
       <Title>About Us</Title>

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -5,7 +5,7 @@ import Title from '../components/Title.astro'
 import Layout from '../layouts/Layout.astro'
 ---
 
-<Layout title="Welcome to Zen">
+<Layout title="Donate - Zen Browser">
   <main class="flex h-screen flex-col items-center justify-center">
     <div class="mb-24 p-4 text-center lg:w-1/2">
       <Title>Donate!</Title>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,7 @@ import Features from '../components/Features.astro'
 import HomeExtras from '../components/HomeExtras.astro'
 ---
 
-<Layout title="Welcome to Zen">
+<Layout title="Zen Browser">
   <main>
     <Hero />
     <Community />

--- a/src/pages/release-notes/index.astro
+++ b/src/pages/release-notes/index.astro
@@ -5,7 +5,7 @@ import { releaseNotes } from '../../release-notes'
 import Title from '../../components/Title.astro'
 ---
 
-<Layout title="Release Notes">
+<Layout title="Release Notes - Zen Browser">
 	<main
 		class="flex h-full min-h-[1000px] flex-1 flex-col items-center justify-center py-4"
 	>


### PR DESCRIPTION
Revised page titles to improve branding and user experience:

- Updated `/title` from "Welcome to Zen" to "Zen Browser"
- Updated `/release-notes` title from "Release Notes" to "Release Notes
- Zen Browser"
- Updated `/donate` title to "Donate - Zen Browser"
- Updated `/about` title to "About - Zen Browser"

Enhances consistency and SEO across key pages