### PR TITLE
fix: fixed spacing for multiple pages being cut off on device screens

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,7 +6,7 @@ import Layout from '../layouts/Layout.astro'
 ---
 
 <Layout title="About - Zen Browser">
-  <main class="min-h-screen h-screen relative flex flex-col my-52 justify-center items-center">
+  <main class="min-h-screen relative flex flex-col my-44 justify-center items-center">
     <div class="text-center p-4 mb-24 lg:w-1/2">
       <Title>About Us</Title>
       <Description>

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -6,7 +6,7 @@ import Layout from '../layouts/Layout.astro'
 ---
 
 <Layout title="Donate - Zen Browser">
-  <main class="flex my-52 flex-col items-center justify-center">
+  <main class="flex my-44 flex-col items-center justify-center">
     <div class="mb-24 p-4 text-center lg:w-1/2">
       <Title>Donate!</Title>
       <Description>

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -6,7 +6,7 @@ import Layout from '../layouts/Layout.astro'
 ---
 
 <Layout title="Donate - Zen Browser">
-  <main class="flex h-screen flex-col items-center justify-center">
+  <main class="flex my-52 flex-col items-center justify-center">
     <div class="mb-24 p-4 text-center lg:w-1/2">
       <Title>Donate!</Title>
       <Description>

--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -17,7 +17,7 @@ const appleIcon = icon({ prefix: "fab", iconName: "apple" });
 ---
 
 <Layout title="Welcome to Zen">
-  <main class="flex flex-col justify-center items-center mt-52 2xl:mt-0">
+  <main class="flex flex-col justify-center items-center mt-44">
     <div class="flex justify-center flex-col px-2 md:px-12 lg:px-0 lg:flex-row xl:justify-start">
       <Image src={myImage} alt="Zen Browser" class="w-24 h-24" />
       <div class="p-4 mb-24 lg:w-1/2 flex flex-col gap-12">

--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -17,7 +17,7 @@ const appleIcon = icon({ prefix: "fab", iconName: "apple" });
 ---
 
 <Layout title="Welcome to Zen">
-  <main class="h-screen flex flex-col justify-center items-center mt-52 2xl:mt-0">
+  <main class="flex flex-col justify-center items-center mt-52 2xl:mt-0">
     <div class="flex justify-center flex-col px-2 md:px-12 lg:px-0 lg:flex-row xl:justify-start">
       <Image src={myImage} alt="Zen Browser" class="w-24 h-24" />
       <div class="p-4 mb-24 lg:w-1/2 flex flex-col gap-12">


### PR DESCRIPTION
This fix removes the use of "h-screen" for setting the height of the page to screen, which causes clipping behaviour on small and large viewports. Replaced with the use of margins.

Example of old using devtools to push the content:
![{F746BE9D-06B5-4435-B2E2-A682AAE4822A}](https://github.com/user-attachments/assets/7ab3e364-921c-4dd9-b068-34b96b4cf373)
New:
![{E5D46F86-E6DC-47CE-B59F-91E92DE15068}](https://github.com/user-attachments/assets/2b255fab-8b0c-48ba-888e-1970bd81c7d9)

This fix is applied to the pages: "Download", "About Us", and "Donate".