### PR TITLE
fix: adjusted toggle theme button to prevent clipping of the download button on mobile

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -105,7 +105,7 @@ import { ThemeSwitch } from 'free-astro-components'
       </div>
       <div class="flex gap-2">
         <div id="theme-switcher" class="block ml-auto xl:hidden">
-          <ThemeSwitch label="" class="p-2" />
+          <ThemeSwitch label="" class="py-2 px-1" />
         </div>
         <Button href="/download" class="ml-auto" isPrimary>
           <span class="hidden md:flex items-center gap-2">


### PR DESCRIPTION
old: 
![{928EE575-0356-4365-9C1B-0FA90A7BA10D}](https://github.com/user-attachments/assets/24476331-6c5d-4771-a954-15d609c09274)

new:
![{72F0983A-B497-410F-ADA5-41787143FE8C}](https://github.com/user-attachments/assets/97df2984-ab53-4726-a7d7-bc2b9178676d)
