### PR TITLE
fix: adjusted sizing of "beta out now!" hero label for mobile

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -42,7 +42,7 @@ function getHeroTitleAnimation() {
       <motion.span client:load {...getHeroTitleAnimation()}>
         internet
       </motion.span>
-      <motion.div className="absolute top-0 right-0 rounded-full py-1 px-4 !font-bold bg-coral text-paper text-base !rotate-6" client:load {...getHeroTitleAnimation()}>
+      <motion.div className="absolute top-0 right-0 rounded-full py-0 px-2 md:py-1 md:px-4 !font-bold bg-coral text-paper text-sm md:text-base !rotate-6" client:load {...getHeroTitleAnimation()}>
         beta out now!
       </motion.span>
     </Title>


### PR DESCRIPTION
Old:
![{AB883B88-1007-472A-908B-E5CD730E8899}](https://github.com/user-attachments/assets/3f137af4-986e-43ad-b646-6a5145abf8e0)

New:
![{A57614C1-69DB-4448-8166-B31155042649}](https://github.com/user-attachments/assets/1bdaa061-2b1b-4079-932b-474ed50a871e)
