### PR TITLE
fix z-index in navbar

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -11,7 +11,7 @@ import { ThemeSwitch } from 'free-astro-components'
 
 <nav
   id="nav-bar"
-  class="fixed flex justify-between w-full items-center lg:pt-6 lg:px-6 z-10 top-0 left-0"
+  class="fixed flex justify-between w-full items-center lg:pt-6 lg:px-6 z-20 top-0 left-0"
 >
   <Astronav>
     <MenuItems class="w-full lg:w-fit lg:rounded-full border-dark border-b-2 lg:border-2 p-2 backdrop-blur-2xl bg-paper dark:bg-paper dark:shadow-md mx-auto flex gap-2 lg:gap-20">


### PR DESCRIPTION
The navbar hides behind one of the images inside the customization section. The images has the same z-index as the navbar. This PR increases the z-index of the navbar to fix this:

![Screenshot 2024-12-18 at 10 27 00](https://github.com/user-attachments/assets/7ff01bf9-9a6f-4be1-94e7-8bd6fa919065)
