### PR TITLE
fix: loads critical :root CSS in <head> (2nd attempt at fixing flashbang)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -56,6 +56,7 @@ import Footer from '../components/Footer.astro'
         }
       })()
     </script>
+    <style>:root{--zen-paper:#f2f0e3;--zen-dark:#202020;--zen-muted:rgba(0, 0, 0, 0.05);&[data-theme='dark']{--zen-paper:#202020;--zen-dark:#f2f0e3;--zen-muted:rgba(255, 255, 255, 0.05)}}</style>
   </head>
   <body
     class="overflow-x-hidden bg-paper font-['bricolage-grotesque'] text-dark"
@@ -74,18 +75,6 @@ import Footer from '../components/Footer.astro'
   @font-face {
     font-family: 'Junicode-Italic';
     src: url('/fonts/JunicodeVF-Italic.woff2') format('woff2');
-  }
-
-  :root {
-    --zen-paper: #f2f0e3;
-    --zen-dark: #202020;
-    --zen-muted: rgba(0, 0, 0, 0.05);
-
-    &[data-theme='dark'] {
-      --zen-paper: #202020;
-      --zen-dark: #f2f0e3;
-      --zen-muted: rgba(255, 255, 255, 0.05);
-    }
   }
 
   * {


### PR DESCRIPTION
this has minimal to no performance loss since CSS is minified and it's only the root selector. loading :root in head can minimize flashes in other areas as well (if they were to ever occur).