### PR TITLE
fix: adds site config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,4 +7,5 @@ import react from '@astrojs/react';
 // https://astro.build/config
 export default defineConfig({
     integrations: [tailwind(), react()],
+    site: 'https://zen-browser.app',
 });


### PR DESCRIPTION
problem: we don't have 'site' config in astro config. this makes Astro.url.origin API function render localhost in production.