### PR TITLE
fix: fixes image sizing on 4k displays for home page

### DIFF
--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -75,7 +75,7 @@ import { getTitleAnimation, getZoomInAnimation } from '../animations'
         </div>
       </motion.div>
     </div>
-    <div class="relative lg:w-2/3 lg:pl-20 items-center m-auto">
+    <div class="relative lg:w-2/3 3xl:w-2/5 lg:pl-20 items-center m-auto">
       <div class="ml-auto" id="feature-list-image">
         <Image src={browserWorkspaces} alt="Browser Workspaces" class="rounded-xl shadow border-4 border-white" />
         <Image src={browserCompactMode} alt="Browser Compact Mode" class="rounded-xl shadow border-4 border-white" />

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -75,7 +75,7 @@ import { getTitleAnimation, getZoomInAnimation } from '../animations'
         </div>
       </motion.div>
     </div>
-    <div class="relative lg:w-2/3 3xl:w-2/5 lg:pl-20 items-center m-auto">
+    <div class="relative lg:w-2/3 3xl:w-1/2 lg:pl-20 items-center m-auto">
       <div class="ml-auto" id="feature-list-image">
         <Image src={browserWorkspaces} alt="Browser Workspaces" class="rounded-xl shadow border-4 border-white" />
         <Image src={browserCompactMode} alt="Browser Compact Mode" class="rounded-xl shadow border-4 border-white" />

--- a/src/components/HomeExtras.astro
+++ b/src/components/HomeExtras.astro
@@ -12,7 +12,7 @@ import { ArrowRight } from 'lucide-astro';
 
 <section
   id="customization"
-  class="flex w-full 3xl:my-32 px-4 lg:px-12 xl:px-24 py-36 pt-24 gap-16 flex-col lg:flex-row relative overflow-y-hidden"
+  class="flex w-full px-4 lg:px-12 xl:px-24 py-36 pt-24 gap-16 flex-col lg:flex-row relative overflow-y-hidden"
 >
   <div>
     <Title>Customizable<br class="md:hidden" /> to <br class="hidden md:block" />the last pixel</Title>

--- a/src/components/HomeExtras.astro
+++ b/src/components/HomeExtras.astro
@@ -12,7 +12,7 @@ import { ArrowRight } from 'lucide-astro';
 
 <section
   id="customization"
-  class="flex w-full px-4 lg:px-12 xl:px-24 py-36 pt-24 gap-16 flex-col lg:flex-row relative overflow-y-hidden"
+  class="flex w-full 3xl:my-32 px-4 lg:px-12 xl:px-24 py-36 pt-24 gap-16 flex-col lg:flex-row relative overflow-y-hidden"
 >
   <div>
     <Title>Customizable<br class="md:hidden" /> to <br class="hidden md:block" />the last pixel</Title>
@@ -27,9 +27,9 @@ import { ArrowRight } from 'lucide-astro';
     </div>
   </div>
   <div class="relative ml-16 h-32 lg:mx-0 lg:w-1/2 flex" id="browser-images">
-    <Image src={browserCollapsed} alt="Zen browser" class="w-2/3 rounded-md shadow-md absolute top-[5%] left-[65%] -translate-x-1/2" />
-    <Image src={browseMultiToolbar} alt="Zen browser" class="w-2/3 rounded-md mx-auto absolute top-1/2 left-1/2 transform -translate-x-1/2" />
-    <Image src={browserSingleToolbar} alt="Zen browser" class="w-2/3 rounded-md shadow-md absolute top-[15%] left-[10%] z-10 -translate-x-1/2" />
+    <Image src={browserCollapsed} alt="Zen browser" class="w-2/3 3xl:w-1/3 rounded-md 3xl:rounded-lg shadow-md absolute top-[5%] left-[65%] -translate-x-1/2" />
+    <Image src={browseMultiToolbar} alt="Zen browser" class="w-2/3 3xl:w-1/3 rounded-md 3xl:rounded-lg mx-auto absolute top-1/2 left-1/2 3xl:left-[55%] transform -translate-x-1/2" />
+    <Image src={browserSingleToolbar} alt="Zen browser" class="w-2/3 3xl:w-1/3 rounded-md 3xl:rounded-lg shadow-md absolute top-[15%] left-[10%] 3xl:left-[35%] z-10 -translate-x-1/2" />
   </div>
 </section>
 <style>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -7,6 +7,7 @@ export default {
 			screens: {
 				'-md': '@media (min-width: 768px)',
 				'-lg': '@media (min-width: 1024px)',
+				'3xl': '2560px'
 			},
 			colors: {
 				"paper": "var(--zen-paper)",


### PR DESCRIPTION
problem: we don't have proper handling of elements for 4k displays. this causes warping on 2 of the home images.
fix: added a new breakpoint for 4k displays to tailwind config, and applied fixes to the images using that breakpoint. below are comparisons (using chrome because I hate firefox responsiveness editor).

old:
![{F69D6943-A36A-4F9A-A79E-B10921671EE0}](https://github.com/user-attachments/assets/71e4df53-6381-481a-847f-1584e0ccb908)
![{F79F1468-FF5F-4CA1-85B0-C33C9F533639}](https://github.com/user-attachments/assets/0988bd8e-0bd7-4625-9861-8a09e6e0db9a)

new:
![{E98DDB1F-A883-4E88-9277-AF68F7A38E8A}](https://github.com/user-attachments/assets/528cbc7f-02f0-4408-8c9e-6b10b0173a9f)
![{7E6D3706-E78C-4201-AC1E-7EC4B434C057}](https://github.com/user-attachments/assets/91e453ee-672c-482b-80b0-f3de7fcb29f0)
