### PR TITLE
feat(navigation): add breadcrumb navigation to the website

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@types/react": "^19.0.1",
 		"@types/react-dom": "^19.0.2",
 		"astro": "^5.0.4",
+		"astro-breadcrumbs": "^3.3.1",
 		"astro-navbar": "^2.3.7",
 		"autoprefixer": "10.4.14",
 		"date-fns": "^4.1.0",

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,23 @@
+---
+import { Breadcrumbs } from "astro-breadcrumbs";
+import "astro-breadcrumbs/breadcrumbs.css";
+---
+
+<nav class="absolute top-[115px] left-1/2 transform -translate-x-1/2 z-10 w-full flex justify-center">
+  <Breadcrumbs schemaJsonScript={false}>
+    <svg
+      slot="separator"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="9 18 15 12 9 6"></polyline>
+    </svg>
+  </Breadcrumbs>
+</div>

--- a/src/components/CustomBreadcrumb.astro
+++ b/src/components/CustomBreadcrumb.astro
@@ -1,0 +1,47 @@
+---
+import { Breadcrumbs } from "astro-breadcrumbs";
+import "astro-breadcrumbs/breadcrumbs.css";
+
+// Custom breadcrumb data
+const { titles, links, currentPath } = Astro.props;
+const customCrumbs = [
+  {
+    text: titles.home,
+    href: links.home,
+  },
+  {
+    text: titles.mods,
+    href: links.mods,    
+  },
+  {
+    text: titles.modName, 
+    href: currentPath    
+  }
+];
+---
+
+<nav class="absolute left-1/2 transform -translate-x-1/2 z-10 w-full flex justify-center top-[115px]">
+  <Breadcrumbs crumbs={customCrumbs} schemaJsonScript={false}>
+    <svg
+      slot="separator"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="9 18 15 12 9 6"></polyline>
+    </svg>
+  </Breadcrumbs> 
+</nav>
+
+<style>    
+    :root {            
+        --visibility-truncated-breadcrumbs: visible;
+        --position-truncated-breadcrumbs: relative;
+    }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,11 @@ const { title } = Astro.props
 import '@fontsource/bricolage-grotesque/400.css'
 import NavBar from '../components/NavBar.astro'
 import Footer from '../components/Footer.astro'
+import Breadcrumb from '../components/Breadcrumb.astro'
+
+// The two-level breadcrumb will not be shown if the URL is the home page ("/") or a mod page ("/mods/*")
+const pathname = Astro.url.pathname;
+const showBreadcrumb = !(pathname === '/' || pathname.startsWith('/mods/'));
 ---
 
 <!doctype html>
@@ -63,6 +68,7 @@ import Footer from '../components/Footer.astro'
     class="overflow-x-hidden bg-paper font-['bricolage-grotesque'] text-dark"
   >
     <NavBar />
+    {showBreadcrumb && <Breadcrumb />}
     <slot />
     <Footer />
   </body>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -131,4 +131,21 @@ const showBreadcrumb = !(pathname === '/' || pathname.startsWith('/mods/'));
     height: 1em;
     vertical-align: -0.125em;
   }
+
+  /* astro-breadcrumbs layout on mobile */
+  .c-breadcrumbs__link.is-current {
+    text-overflow: ellipsis !important;
+    overflow: hidden !important;
+    white-space: nowrap !important;
+  }
+  @media(max-width: 600px) {
+    .c-breadcrumbs__link.is-current {
+      max-width: 200px !important;            
+    }
+  }
+  @media(max-width: 500px) {
+    .c-breadcrumbs__link.is-current {      
+      max-width: 130px !important;      
+    }
+  }
 </style>

--- a/src/pages/mods/[...slug].astro
+++ b/src/pages/mods/[...slug].astro
@@ -7,6 +7,7 @@ import Description from '../../components/Description.astro';
 import Button from '../../components/Button.astro';
 import BackButton from '../../components/BackButton.astro';
 import { Info } from 'lucide-astro';
+import CustomBreadcrumb from '../../components/CustomBreadcrumb.astro'
 
 export async function getStaticPaths() {
   const mods = await getAllMods();
@@ -24,14 +25,28 @@ const dates = {
   createdAt: getLocalizedDate(mod.createdAt),
   updatedAt: getLocalizedDate(mod.updatedAt)
 }
+
+// Breadcrumb data for the three-level breadcrumb
+const currentPath = Astro.request.url;
+const titles = {
+  home: "Home",
+  mods: "Mods",
+  modName: mod.name, 
+};
+const links = {
+  home: "/",
+  mods: "/mods",
+  modName: currentPath, 
+};
 ---
 
 <Layout title={`${mod.name} - Zen Mods`} >
+  <CustomBreadcrumb titles={titles} links={links} currentPath={currentPath} />
   <main class="mt-6 2xl:mt-0">
     <div class="px-8 mx-auto flex flex-col lg:w-1/2 gap-6 mt-20 lg:mt-32 mb-24">
       <div
         id="install-theme-error"
-        class="flex flex-col md:flex-row items-center justify-center md:justify-between gap-2 rounded-xl bg-red-200 p-2 px-4"
+        class="flex flex-col md:flex-row items-center justify-center md:justify-between mt-[75px] lg:mt-[25px] gap-2 rounded-xl bg-red-200 p-2 px-4"
       >
         <div class="flex items-center gap-2 text-center md:text-left">
           <Info />


### PR DESCRIPTION
This pull request introduces the breadcrumb navigation to the website pages.

## Details

- **Position**: The breadcrumb is placed at the top of the page and is centered.
- **Dynamic**: Reflects the page hierarchy dynamically (e.g., Home > Category > Current Page).
- **Dependency**: The breadcrumb is generated using the `astro-breadcrumbs`  dependency: https://docs.astro-breadcrumbs.kasimir.dev/

## Screenshots

| Desktop | 
|---|
| ![breadcrumb-navigantion-mod-details-page](https://github.com/user-attachments/assets/fe7d75c6-571f-44e0-9d2f-9dd2926fedb2) |

| Mobile Light Theme | Mobile Dark Theme |
|---|---|
| ![breadcrumb-navigantion-mod-details-page-mobile](https://github.com/user-attachments/assets/1ea8757f-3043-47a7-ad34-2b5a59133cf4) | ![breadcrumb-navigantion-dark-theme-mobile](https://github.com/user-attachments/assets/4c74127c-1de6-43cc-b5f9-82110a263b31) |

## User Experience

- **Navigation and Accessibility**: The breadcrumb help users easily understand and navigate the page hierarchy, making it simpler to return to previous levels and preventing them from getting lost.
- **Reduces Bounce Rate**: By offering a clear indication of the user's current location on the site, the breadcrumb encourage further exploration and reduce the likelihood of users leaving the site. Learn more: https://yoast.com/breadcrumbs-seo/.