### PR TITLE
fix: tailwind config dark mode detection

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
 	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
-	darkMode: 'media',
+	darkMode: [ 'selector' , '[data-theme="dark"]'],
 	theme: {
 		extend: {
 			screens: {


### PR DESCRIPTION
## Description

Tailwind dark mode was not correctly set up, this was causing the `dark:` styles to not be applied correctly.

[Tailwind docs](https://tailwindcss.com/docs/dark-mode#customizing-the-selector)

### Before
<img width="800" alt="image" src="https://github.com/user-attachments/assets/3e9718b5-38f7-4c0d-b1c7-a42353fd49cd" />

### After
<img width="799" alt="image" src="https://github.com/user-attachments/assets/2cb41da1-bea9-40a9-83fc-a73179223940" />
