### PR TITLE
Contributor github redirect

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -43,8 +43,8 @@ import Layout from '../layouts/Layout.astro'
         <Description>
           Here are all the wonderful people that decided to contribute to the project! The first set of images are from the desktop repository, and the second set is from the website repository.
         </Description>
-        <img src="https://contributors-img.web.app/image?repo=zen-browser/desktop" alt="Contributors" class="mt-4" />
-        <img src="https://contributors-img.web.app/image?repo=zen-browser/www" alt="Contributors (website)" class="mt-4" />
+        <a href="https://github.com/zen-browser/desktop/graphs/contributors"><img src="https://contributors-img.web.app/image?repo=zen-browser/desktop" alt="Contributors" class="mt-4" /></a>
+        <a href="https://github.com/zen-browser/www/graphs/contributors"><img src="https://contributors-img.web.app/image?repo=zen-browser/www" alt="Contributors (website)" class="mt-4" /></a>
       </div>
     </div>
   </main>


### PR DESCRIPTION
Image (in about us page) redirect to GitHub contributor page


![image](https://github.com/user-attachments/assets/0df24fd9-6502-4f51-aacb-15b6d0ab7c6b)
