### PR TITLE
Lowercase Hero Heading

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -37,7 +37,7 @@ function getHeroTitleAnimation() {
       class="relative px-12 text-left !font-normal leading-[108px] md:text-center md:!text-7xl lg:px-0 lg:!text-9xl"
     >
       <motion.span client:load {...getHeroTitleAnimation()}>
-        Welcome
+        welcome
       </motion.span>
       <motion.span client:load {...getHeroTitleAnimation()}> to </motion.span>
       <br class="hidden md:block" />


### PR DESCRIPTION
This way, the user will feel more connected to the word **_`calmer`_** while reading the heading. Currently, the capital **`W`** in **`Welcome`** is drawing attention away from it.