### PR TITLE
fix:disable windows zip download option

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -233,7 +233,7 @@ const appleIcon = icon({ prefix: 'fab', iconName: 'apple' })
                 <HardDriveDownload class="size-4" />
               </div>
               <div
-                class="flex cursor-not-allowed cursor-pointer items-center justify-between rounded-md border-2 border-dark p-2 px-4 text-dark opacity-50 shadow-sm transition-all duration-100 hover:bg-dark hover:text-paper"
+                class="flex cursor-not-allowed items-center justify-between rounded-md border-2 border-dark p-2 px-4 text-dark opacity-50 shadow-sm transition-all duration-100 hover:bg-dark hover:text-paper"
                 id="windows-zip-download"
               >
                 Download Zip


### PR DESCRIPTION
Issue:https://github.com/zen-browser/www/issues/422
and https://github.com/zen-browser/www/issues/415

The zip file download option is commented out  

```
 document
    .getElementById('windows-zip-download')
    ?.addEventListener('click', () => {
      //downloadRelease("windows", selectedArch as string, "zip");
    })
```

so  in 
```
  <div
                class="flex cursor-not-allowed cursor-pointer items-center justify-between rounded-md border-2 border-dark p-2 px-4 text-dark opacity-50 shadow-sm transition-all duration-100 hover:bg-dark hover:text-paper"
                id="windows-zip-download"
              >
                Download Zip
                <HardDriveDownload class="size-4" />
              </div>

```
Only cursor-not-allowed should be present. The cursor-pointer class should be removed

https://github.com/user-attachments/assets/65258369-d0d5-41e0-8954-245b212c073c