### PR TITLE
fix: redirect old /themes URLs to new /mods

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,4 +16,7 @@ export default defineConfig({
     }),
   ],
   site: 'https://zen-browser.app',
+  redirects: {
+    '/themes/[...slug]': '/mods/[...slug]',
+  },
 })


### PR DESCRIPTION
Since `/themes` was changed to `/mods`, I've frequently come across links to the old path that now lead to a 404. This PR adds a redirect from `/themes` to `/mods` to keep those old links functioning!