### PR TITLE
feat: removes twitter/x meta tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -54,8 +54,6 @@ import Footer from '../components/Footer.astro'
       content="Beautifully designed, privacy-focused, and packed with features. We care about your experience, not your data.."
     />
     <meta property="og:color" content="#da755b3" />
-    <!-- twitter card -->
-    <meta name="twitter:card" content="summary_large_image" />
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link


### PR DESCRIPTION
many people are moving away from Twitter/X because of the recent... stuff that has happened. i'm personally against Twitter/X and all the recent political stuff. there are other people in the web dev community pulling away from Twitter/X as well.

merge this, or don't. this isn't life-changing or anything. it'll just break embeds when the website's URL is shared to Twitter/X.