### PR TITLE
Fix to flashbang until we figure out the issue

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -95,6 +95,14 @@ import Footer from '../components/Footer.astro'
     box-sizing: border-box;
   }
 
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) {
+      --zen-paper: #202020;
+      --zen-dark: #f2f0e3;
+      --zen-muted: rgba(255, 255, 255, 0.05);
+    }
+  }
+
   :root {
     --zen-paper: #f2f0e3;
     --zen-dark: #202020;
@@ -109,6 +117,7 @@ import Footer from '../components/Footer.astro'
 
   html {
     scroll-behavior: smooth;
+    color-scheme: light dark;
   }
 
   body,


### PR DESCRIPTION
I've added a css line which makes the website default to dark mode if user has `prefers-color-scheme: dark`, which can be overrided with `&[data-theme='dark']`.

This should fix the flashbang for most people until we figure out why prod has this specific issue and its solution.