### PR TITLE
feat: cleaned up the community page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -34,76 +34,76 @@ import Layout from '../layouts/Layout.astro'
           <ul>
             <li class="text-sm">
               <a href="https://github.com/mauro-balades"
-                ><strong class="font-bold">Mauro Baladés</strong></a
-              ><span class="opacity-60">: Creator, Main Developer</span>
+                ><strong class="font-bold underline">Mauro Baladés</strong></a
+              ><span class="opacity-60"> : Creator, Main Developer</span>
             </li>
-            <li class="mt-1 text-sm">
-              <strong class="italic">Oscar Gonzalez</strong><span
+            <li class="mt-2 text-sm">
+              <strong class="font-bold">Oscar Gonzalez</strong><span
                 class="opacity-60"
               >
-                Site Reliability Engineer (SRE) and code signing.</span
+               : Site Reliability Engineer (SRE) and code signing.</span
               >
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://janheres.eu/"
-                ><strong class="font-bold">Jan Heres</strong></a
+                ><strong class="font-bold underline">Jan Heres</strong></a
               ><span class="opacity-60"
-                >: Active contributor and helps with MacOS builds</span
+                > : Active contributor and helps with MacOS builds</span
               >
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://github.com/BrhmDev"
-                ><strong class="font-bold">BrhmDev</strong></a
+                ><strong class="font-bold underline">BrhmDev</strong></a
               ><span class="opacity-60"
-                >: Active contributor with great contributions</span
+                > : Active contributor with great contributions</span
               >
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://thatcanoa.org/"
-                ><strong class="font-bold">Canoa</strong></a
+                ><strong class="font-bold underline">Canoa</strong></a
               ><span class="opacity-60"
-                >: Active contributor, and very active in issue handling and
+                > : Active contributor, and very active in issue handling and
                 website management</span
               >
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://cybrneon.xyz/"
-                ><strong class="font-bold">Adam</strong></a
-              ><span class="opacity-60">: Branding and design</span>
+                ><strong class="font-bold underline">Adam</strong></a
+              ><span class="opacity-60"> : Branding and design</span>
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://github.com/kristijanribaric"
-                ><strong class="font-bold">kristijanribaric</strong></a
-              ><span class="opacity-60">: Active contributor</span>
+                ><strong class="font-bold underline">kristijanribaric</strong></a
+              ><span class="opacity-60"> : Active contributor</span>
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://github.com/n7itro"
-                ><strong class="font-bold">n7itro</strong></a
+                ><strong class="font-bold underline">n7itro</strong></a
               ><span class="opacity-60"
-                >: Active contributor and release notes writer</span
+                > : Active contributor and release notes writer</span
               >
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://josuegalre.netlify.app/"
-                ><strong class="font-bold">Bryan Galdámez</strong></a
+                ><strong class="font-bold underline">Bryan Galdámez</strong></a
               ><span class="opacity-60"
-                >: Huge contributor on theme functionalities</span
+                > : Huge contributor on theme functionalities</span
               >
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://iamjafeth.com/"
-                ><strong class="font-bold">Jafeth Garro</strong></a
-              ><span class="opacity-60">: Documentation writer</span>
+                ><strong class="font-bold underline">Jafeth Garro</strong></a
+              ><span class="opacity-60"> : Documentation writer</span>
             </li>
-            <li class="mt-1 text-sm">
+            <li class="mt-2 text-sm">
               <a href="https://github.com/LarveyOfficial/"
-                ><strong class="font-bold">Larvey</strong></a
-              ><span class="opacity-60">: AUR maintainer</span>
+                ><strong class="font-bold underline">Larvey</strong></a
+              ><span class="opacity-60"> : AUR maintainer</span>
             </li>
-            <li class="mt-1 text-sm">
-              <strong class="italic">Daniel García</strong><span
+            <li class="mt-2 text-sm">
+              <strong class="font-bold">Daniel García</strong><span
                 class="opacity-60"
-                >: MacOS certificate and app notarization maintainer</span
+                > : MacOS certificate and app notarization maintainer</span
               >
             </li>
           </ul>
@@ -122,14 +122,14 @@ import Layout from '../layouts/Layout.astro'
           ><img
             src="https://contributors-img.web.app/image?repo=zen-browser/desktop"
             alt="Contributors"
-            class="mt-4"
+            class="mt-8"
           /></a
         >
         <a href="https://github.com/zen-browser/www/graphs/contributors"
           ><img
             src="https://contributors-img.web.app/image?repo=zen-browser/www"
             alt="Contributors (website)"
-            class="mt-4"
+            class="mt-8"
           /></a
         >
       </div>


### PR DESCRIPTION
Before:
![{4DD9C7B6-2FC1-4BFE-AAA8-382C62E310DE}](https://github.com/user-attachments/assets/c65ebe42-b8b0-4edf-b9b8-0fbc6adca061)

After:
![{28C0B274-0CF2-4FFD-8926-BD6AA19EAA35}](https://github.com/user-attachments/assets/98505e17-6317-4c66-bbaf-407bb844952a)

Changes:
- Added spacing between the colons ( : ) between the names of main team and their descriptions.
- Removed italics and added underline to everyone else. I questioned why there was italics but then realized it's probably because the people in italics didn't have an href to their name. Thus, I opted to remove the italics and add underlines for all the people that did have hrefs.
- Increased spacing between names of main team.
- Increased top margin on contributor images to add extra spacing.