### PR TITLE
 Fix issue with back button on Mods page 

### DIFF
--- a/src/components/ModsList.tsx
+++ b/src/components/ModsList.tsx
@@ -72,17 +72,16 @@ export default function ModsList({ mods }: ModsListProps) {
   }
 
   function getPageUrl(pageNum: number) {
-    let link = '/mods'
-
+    const params = new URLSearchParams(searchParams)
+    
     if (pageNum > 1) {
-      link += `?page=${pageNum}`
+      params.set('page', pageNum.toString())
+    } else {
+      params.delete('page')
     }
 
-    if (searchParams) {
-      link += `&${searchParams.toString()}`
-    }
-
-    return link
+    const queryString = params.toString()
+    return `/mods${queryString ? `?${queryString}` : ''}`
   }
 
   function renderPagination() {


### PR DESCRIPTION
clicking the Back button on the Mods page (specifically on page 2) incorrectly redirects to the homepage instead of the previous page (Page 1)