### PR TITLE
Actually inject the schema to homepage on build

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,10 +1,10 @@
 ---
 interface Props {
   title: string
+  isHome?: boolean
 }
 
-const { title } = Astro.props
-const onHomepage = Astro.url.origin === 'https://zen-browser.app/'
+const { title, isHome } = Astro.props
 import '@fontsource/bricolage-grotesque/400.css'
 import NavBar from '../components/NavBar.astro'
 import Footer from '../components/Footer.astro'
@@ -38,9 +38,9 @@ import Footer from '../components/Footer.astro'
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="sitemap" href="/sitemap-0.xml" />
 
-    <!-- Injecting schema to homepage only (for SEO) -->
-    {onHomepage && (
-      <script type="application/ld+json">
+    {isHome && (
+      <!-- Injecting schema to homepage only (for SEO) -->
+      <script is:inline type="application/ld+json">
       {{
         "@context":"https://schema.org",
         "@type":"WebSite",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,7 @@ import Features from '../components/Features.astro'
 import HomeExtras from '../components/HomeExtras.astro'
 ---
 
-<Layout title="Zen Browser">
+<Layout title="Zen Browser" isHome>
   <main>
     <Hero />
     <Community />


### PR DESCRIPTION
This is a fix to #436 which adds a schema to improve SEO.

Closes #390

```tsx
const onHomepage = Astro.url.origin === 'https://zen-browser.app/'
```
This does not work on Astro as it builds on server, which does not have the domain as its url origin.
I have fixed it to be an optional boolean prop which can be passed from `index.astro`.
