### PR TITLE
Make cf rocket loader ignore theme script

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ import NavBar from '../components/NavBar.astro'
 import Footer from '../components/Footer.astro'
 ---
 
-<script is:inline>
+<script is:inline data-cfasync="false">
   const theme = (() => {
     if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
       return localStorage.getItem('theme') ?? 'light'


### PR DESCRIPTION
Adding `data-cfasync="false"` will make rocket loader ignore this script according to their docs.
This should fix the theme script being deferred on load until page has fully loaded by cf.
Source: https://developers.cloudflare.com/speed/optimization/content/rocket-loader/ignore-javascripts/