### PR TITLE
bug(download.astro): Removed Continue Button from Macos Download Option

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -412,6 +412,7 @@ const appleIcon = icon({ prefix: 'fab', iconName: 'apple' })
       osSelectLinux.checked = true
     } else if (navigator.platform.includes('Mac')) {
       osSelectMacOS.checked = true
+      showButton('next-button', false)
     }
   }
 
@@ -439,10 +440,17 @@ const appleIcon = icon({ prefix: 'fab', iconName: 'apple' })
     goPreviousForm()
   })
 
+  document.getElementById('macos-select')?.addEventListener('click', () => {
+    downloadRelease('macos', 'universal')
+    showButton('next-button', false)
+  })
+  document.getElementById('os-select-linux')?.addEventListener('click', () => {
+    showButton('next-button', true)
+  })
   document
-    .getElementById('macos-select')
+    .getElementById('os-select-windows')
     ?.addEventListener('click', () => {
-      downloadRelease('macos', 'universal')
+      showButton('next-button', true)
     })
 
   document


### PR DESCRIPTION
**Bug:** The Continue Button On the Download Page Stayed Visible while downloading for macOS(which should only be visible for Linux & Windows for selecting architecture type on the next form).

**Change Made:** Made the continue button hidden when it loads for macOS, and made them reappear, whenever Windows/Linux is clicked.

**Changed Files**: 
1. src/download.astro

**Screen Recording After Fix:**

https://github.com/user-attachments/assets/0ea0e6ba-582a-4fa4-bf8b-b450f2226643



Note: Just Downloaded Zen, faced this minor bug while downloading.