### PR TITLE
fix(hero): update download button text to reflect beta availability

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -25,15 +25,6 @@ function getHeroTitleAnimation() {
   class="flex w-full flex-col items-center gap-[20%] py-32 pb-16 text-center md:pb-32 lg:gap-[15%] lg:pb-16"
 >
   <div class="flex h-full flex-col items-center justify-center">
-    <motion.a
-      href="/download"
-      className="transition-bg mb-10 flex items-center gap-2 rounded-full border-2 border-dark bg-dark px-2 py-0 py-1 text-sm text-paper shadow-sm hover:bg-paper hover:text-dark hover:duration-200 md:px-4"
-      client:load
-      {...getTitleAnimation(1.8)}
-    >
-      <div>Beta is now available!</div>
-      <ArrowRight class="size-4" />
-    </motion.a>
     <Title
       class="relative px-12 text-left !font-normal leading-[108px] md:text-center md:!text-7xl lg:px-0 lg:!text-9xl"
     >
@@ -63,7 +54,7 @@ function getHeroTitleAnimation() {
     <div class="mt-6 flex w-2/3 flex-col gap-3 sm:gap-6 md:w-fit md:flex-row">
       <motion.span client:load {...getHeroTitleAnimation()}>
         <Button class="w-full" href="/download" isPrimary>
-          Download
+          Beta is now available!
           <ArrowRight class="size-4" />
         </Button>
       </motion.span>


### PR DESCRIPTION
Changes Made:
- Removed the "Beta is now available!" link to simplify the hero interface.
- Updated the download button text to read "Beta is now available!" or "Join beta now"
- The Download option remains in the navbar.

This update enhances user experience by focusing on clarity and removing unnecessary information.

<details>
  <summary>Before</summary>
  
  ![image](https://github.com/user-attachments/assets/fdb49ccf-f9f1-4d68-bc3a-820d4302a1bd)

</details>

<details>
  <summary>After</summary>
  
  ![image](https://github.com/user-attachments/assets/90c141fe-3127-47f0-b5ca-2ee51bfd45f6)

</details>
