### PR TITLE
Fix the github workflow ID of 1.7.5b in release note

### DIFF
--- a/src/release-notes/stable.json
+++ b/src/release-notes/stable.json
@@ -2202,7 +2202,7 @@
       "New tabs have been removed, check the features section",
       "Replaced default toolbar layout, the profile button with the settings icon"
     ],
-    "workflowId": 13184385191,
+    "workflowId": 13194954146,
     "date": "05/02/2025"
   }
 ]


### PR DESCRIPTION
The current [workflow run](https://github.com/zen-browser/desktop/actions/runs/13184385191) link in the release note of the latest version leads to a 404 page. I changed it with the one triggered on commit e353d48, which is tagged 1.7.5b now.