### PR TITLE
feat: add Keyboard action for enhanced accessibility

### DIFF
--- a/src/components/Community.astro
+++ b/src/components/Community.astro
@@ -5,6 +5,7 @@ import Button from '../components/Button.astro'
 import { motion } from 'motion/react'
 import { Github, Check } from 'lucide-astro'
 import { getTitleAnimation } from '../animations'
+import KeyboardButton from './KeyboardButton.astro'
 ---
 
 <section
@@ -32,7 +33,7 @@ import { getTitleAnimation } from '../animations'
     <motion.span client:load {...getTitleAnimation(0.8)}>
       <Button class:list={['px-4']} href="https://github.com/zen-browser">
         <Github class="size-4" />
-        <span>View on GitHub</span>
+        <span>View on <KeyboardButton key="G" />itHub</span>
       </Button>
     </motion.span>
     <motion.div

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -13,6 +13,7 @@ import {
   faTwitter,
   faReddit,
 } from '@fortawesome/free-brands-svg-icons'
+import KeyboardButton from './KeyboardButton.astro'
 
 library.add(faMastodon, faBluesky, faGithub, faTwitter, faReddit)
 const Mastodon = icon({ prefix: 'fab', iconName: 'mastodon' })
@@ -39,7 +40,7 @@ const Reddit = icon({ prefix: 'fab', iconName: 'reddit' })
     class="flex w-full flex-col justify-between gap-6 lg:my-12 lg:flex-row lg:pr-52"
   >
     <Button href="/download" isPrimary class="h-fit w-fit bg-paper !text-dark">
-      Download
+      <KeyboardButton key="D" />ownload
       <ArrowRight class="size-4" />
     </Button>
     <div class="flex flex-col gap-10">
@@ -99,10 +100,17 @@ const Reddit = icon({ prefix: 'fab', iconName: 'reddit' })
     <div class="flex flex-col gap-2">
       <Description class="!font-semibold"> Get Started </Description>
       <div class="flex flex-col opacity-80">
-        <a href="/download" class="font-normal">Download</a>
-        <a href="/mods" class="font-normal">Zen Mods</a>
-        <a href="/release-notes" class="font-normal">Release Notes</a>
-        <a href="/download?twilight" class="font-normal">Twilight</a>
+        <a href="/download" class="font-normal"
+          ><KeyboardButton key="D" />ownload</a
+        >
+        <a href="/mods" class="font-normal"><KeyboardButton key="Z" />en Mods</a
+        >
+        <a href="/release-notes" class="font-normal"
+          ><KeyboardButton key="R" />elease Notes</a
+        >
+        <a href="/download?twilight" class="font-normal"
+          ><KeyboardButton key="T" />wilight</a
+        >
       </div>
     </div>
     <div class="flex flex-col gap-2">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -7,6 +7,7 @@ import myImage from '../assets/browser.png'
 import { ArrowRight } from 'lucide-astro'
 import { motion } from 'motion/react'
 import { getTitleAnimation } from '../animations'
+import KeyboardButton from './KeyboardButton.astro'
 
 let titleAnimationCounter = 0
 function getNewAnimationDelay() {
@@ -53,12 +54,12 @@ function getHeroTitleAnimation() {
     <div class="mt-6 flex w-2/3 flex-col gap-3 sm:gap-6 md:w-fit md:flex-row">
       <motion.span client:load {...getHeroTitleAnimation()}>
         <Button class="w-full" href="/download" isPrimary>
-          Beta is now available!
+          <KeyboardButton key="D" /> Beta is now available!
           <ArrowRight class="size-4" />
         </Button>
       </motion.span>
       <motion.span client:load {...getHeroTitleAnimation()}>
-        <Button href="#features">Explore Zen</Button>
+        <Button href="#features"><KeyboardButton key="E" /> Explore Zen</Button>
       </motion.span>
     </div>
   </div>

--- a/src/components/HomeExtras.astro
+++ b/src/components/HomeExtras.astro
@@ -12,6 +12,7 @@ import Button from './Button.astro'
 import { ArrowRight } from 'lucide-astro'
 
 import { getTitleAnimation, getZoomInAnimation } from '../animations'
+import KeyboardButton from './KeyboardButton.astro'
 ---
 
 <section id="sponsors" class="px-4 lg:flex-row lg:px-12 lg:py-32 xl:px-24">
@@ -60,7 +61,7 @@ import { getTitleAnimation, getZoomInAnimation } from '../animations'
     <div class="mt-4 flex gap-4">
       <motion.span client:load {...getTitleAnimation(0.6)}>
         <Button isPrimary href="/mods">
-          Explore Zen Mods
+          Explore <KeyboardButton key="Z" />en Mods
           <ArrowRight className="size-4" />
         </Button>
       </motion.span>

--- a/src/components/KeyboardButton.astro
+++ b/src/components/KeyboardButton.astro
@@ -1,0 +1,7 @@
+---
+const { key } = Astro.props
+---
+
+<button class="rounded-md border-2 border-dashed border-paper px-2 uppercase">
+  <span>{key}</span>
+</button>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -13,6 +13,7 @@ import {
 import { ArrowRight, ChevronDown, Download, DownloadCloud } from 'lucide-astro'
 import Logo from './Logo.astro'
 import { ThemeSwitch } from 'free-astro-components'
+import KeyboardButton from './KeyboardButton.astro'
 ---
 
 <nav
@@ -118,7 +119,7 @@ import { ThemeSwitch } from 'free-astro-components'
         </div>
         <Button href="/download" class="ml-auto" isPrimary>
           <span class="hidden items-center gap-2 md:flex">
-            Download
+            <KeyboardButton key="D" />ownload
             <ArrowRight class="size-4" />
           </span>
           <span class="md:hidden">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -94,6 +94,127 @@ import Footer from '../components/Footer.astro'
     <Footer />
   </body>
 </html>
+<script>
+  document.addEventListener('keydown', (e) => {
+    if (window.location.pathname.includes('/download')) {
+      handleDownloadPageKey(e);
+    } 
+    handleGeneralKey(e);
+  });
+  
+  function handleDownloadPageKey(e) {
+    const url = window.location.href;
+  
+    switch (e.key) {
+      case 'w':
+        clickAndScroll('os-select-windows');
+        break;
+      case 'l':
+        clickAndScroll('os-select-linux');
+        break;
+      case 'm':
+        document.querySelector('#macos-select')?.click();
+        break;
+      default:
+        handleOsSpecificKeys(e, url);
+    }
+  }
+  
+  function handleOsSpecificKeys(e, url) {
+    if (url.includes('#os-select-windows')) {
+      switch (e.key) {
+        case '1':
+          clickAndScroll('windows-target-x86_64');
+          break;
+        case '2':
+          clickAndScroll('windows-target-arm64');
+          break;
+      }
+    } else if (url.includes('#windows-target-x86_64') || url.includes('#windows-target-arm64')) {
+      handleWindowsTargetKeys(e, url);
+    } else if (url.includes('#os-select-linux')) {
+      switch (e.key) {
+        case '1':
+          clickAndScroll('linux-target-x86_64');
+          break;
+        case '2':
+          clickAndScroll('linux-target-aarch64');
+          break;
+      }
+    } else if (url.includes('#linux-target-x86_64') || url.includes('#linux-target-aarch64')) {
+      handleLinuxTargetKeys(e);
+    }
+  }
+  
+  function handleWindowsTargetKeys(e, url) {
+    const twilight = url.includes('?twilight');
+  
+    switch (e.key) {
+      case '1':
+        document.querySelector('#windows-installer-download')?.click();
+        break;
+      case '2':
+        if (twilight) {
+          document.querySelector('#windows-zip-download')?.click();
+        }
+        break;
+    }
+  }
+  
+  function handleLinuxTargetKeys(e) {
+    switch (e.key) {
+      case '1':
+        document.querySelector('#linux-tar-download')?.click();
+        break;
+      case '2':
+        document.querySelector('#linux-appimage-download')?.click();
+        break;
+      case '3':
+        document.querySelector('#linux-flathub-download')?.click();
+        break;
+    }
+  }
+  
+  function clickAndScroll(targetId) {
+    const targetElement = document.querySelector(`#${targetId}`);
+    if (targetElement) {
+      targetElement.click();
+      window.location.href = `#${targetId}`;
+    }
+  }
+  
+  function handleGeneralKey(e) {
+    switch (e.key) {
+      case 's':
+        window.location.href = '/';
+        break;
+      case 'n':
+        window.location.href = '#nav-bar';
+        break;
+      case 'f':
+        window.location.href = '#footer';
+        break;
+      case 'e':
+        window.location.href = '/#features';
+        break;
+      case 'd':
+        window.location.href = '/download';
+        break;
+      case 'z':
+        window.location.href = '/mods';
+        break;
+      case 'r':
+        window.location.href = '/release-notes';
+        break;
+      case 't':
+        window.location.href = '/download?twilight';
+        break;
+      case 'g':
+        window.open('https://github.com/zen-browser');
+        break;
+    }
+  }
+</script>
 <style is:global>
   @font-face {
     font-family: 'Junicode';


### PR DESCRIPTION
This PR adds features with keyboard shortcuts for pages, navbar, footer, and download sections.

**Keys:**
- **S:** Navigate to the main page.
- **N:** Scroll up to the navbar.
- **F:** Scroll down to the navbar.
- **E:** Navigate to the Features section on the main page.
- **D:** Navigate to the /download page.
- **Z:** Navigate to the /mods page.
- **R:** Navigate to the /release-notes page.
- **T:** Navigate to the Twilight download page.
- **G:** Open GitPage.

**For the Download Page:**
- **M:** Open the macOS download section.
- **L:** Navigate to the Linux section.
- **W:** Navigate to the Windows section.
- **1, 2, 3:** Use these keys to navigate between sections

--- 

Please provide your feedback so that I can move forward, ty

got this idea from zed website
