### PR TITLE
Fixes "Explore Zen" hero button and some language

### DIFF
--- a/src/components/Community.astro
+++ b/src/components/Community.astro
@@ -22,8 +22,8 @@ import Image from 'astro/components/Image.astro'
     {...getTitleAnimation(0.6)}
     className="px-4 md:px-24 lg:w-1/2 lg:px-0"
   >
-    We make it not only a priority but a necessity to ensure that Zen provides
-    always the best experience for you. We are committed to making Zen the most
+    We make it not only a priority, but a necessity to ensure that Zen always provides
+    the best experience for you. We are committed to making Zen the most
     beautiful, productive, and privacy-focused browser out there.
   </motion.p>
   <div

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -14,7 +14,7 @@ const { title1 = 'Productivity', title2 = 'at', title3 = 'its best' } = Astro.pr
 ---
 
 <section
-  id="Community"
+  id="Features"
   class="relative flex w-full flex-col px-4 text-start md:px-24 lg:mx-auto lg:w-3/4 lg:px-0 lg:py-36"
 >
   <Description class="mb-2 text-6xl font-bold">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -60,7 +60,7 @@ function getHeroTitleAnimation() {
         </Button>
       </motion.span>
       <motion.span client:load {...getHeroTitleAnimation()}>
-        <Button href="#features">Explore Zen</Button>
+        <Button href="#Features">Explore Zen</Button>
       </motion.span>
     </div>
   </div>


### PR DESCRIPTION
This PR fixes the "Explore Zen" button on the Hero section of the home page. For some reason, the ID of the "Features" section was set to "Community", which is already the ID for another section.

I've also fixed some grammar on the Community section.