### PR TITLE
Fix missing space in hero description

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -47,10 +47,9 @@ function getHeroTitleAnimation() {
     </Title>
     <motion.span client:load {...getHeroTitleAnimation()}>
       <Description class="px-12 text-center lg:px-0"
-        >Beautifully designed, privacy-focused, and packed with features.</Description
-      >
-      <Description class="px-12 text-center lg:px-0"
-        >We care about your experience, not your data.</Description
+        >Beautifully designed, privacy-focused, and packed with features. <br
+          class="hidden sm:inline"
+        />We care about your experience, not your data.</Description
       >
     </motion.span>
     <div class="mt-6 flex w-2/3 flex-col gap-3 sm:gap-6 md:w-fit md:flex-row">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -47,9 +47,10 @@ function getHeroTitleAnimation() {
     </Title>
     <motion.span client:load {...getHeroTitleAnimation()}>
       <Description class="px-12 text-center lg:px-0"
-        >Beautifully designed, privacy-focused, and packed with features.<br
-          class="hidden md:block"
-        />We care about your experience, not your data.</Description
+        >Beautifully designed, privacy-focused, and packed with features.</Description
+      >
+      <Description class="px-12 text-center lg:px-0"
+        >We care about your experience, not your data.</Description
       >
     </motion.span>
     <div class="mt-6 flex w-2/3 flex-col gap-3 sm:gap-6 md:w-fit md:flex-row">


### PR DESCRIPTION
I've added a space after `features.` and changed `<br />` to show from `sm` instead.