### PR TITLE
Replace the bg for buttons with a subtle background color

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -24,7 +24,7 @@ const {
           : isAlert
             ? 'bg-red-300 text-dark'
             : !isBordered
-              ? 'bg-[rgba(0,0,0,.05)]'
+              ? 'bg-subtle'
               : '!transition-bg border-2 border-dark hover:bg-dark hover:text-paper hover:shadow-sm',
       ]}
     >

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -235,20 +235,20 @@ const {
 
 <style>
   .feature {
-    @apply w-full cursor-pointer select-none rounded-lg p-4 hover:bg-[rgba(0,0,0,.05)] dark:hover:bg-white/10;
+    @apply w-full cursor-pointer select-none rounded-lg p-4 hover:bg-subtle;
     transition: all 0.2s ease-in-out;
-    
+
     &[data-active='true'] {
-      @apply bg-[rgba(0,0,0,.05)] dark:bg-white/10;
+      @apply bg-subtle;
     }
   }
 
   .feature-tab {
-    @apply rounded-lg px-4 py-2 text-lg font-medium hover:bg-[rgba(0,0,0,.05)] dark:hover:bg-white/10;
+    @apply rounded-lg px-4 py-2 text-lg font-medium hover:bg-subtle;
     transition: all 0.2s ease-in-out;
 
     &[data-active='true'] {
-      @apply bg-[rgba(0,0,0,.05)] dark:bg-white/10;
+      @apply bg-subtle;
     }
   }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -127,11 +127,13 @@ import MobileNavBar from '../components/MobileNavBar'
     --zen-paper: #f2f0e3;
     --zen-dark: #2e2e2e;
     --zen-muted: rgba(0, 0, 0, 0.05);
+    --zen-subtle: rgba(0,0,0,0.05);
 
     &[data-theme='dark'] {
       --zen-paper: #1f1f1f;
       --zen-dark: #d1cfc0;
       --zen-muted: rgba(255, 255, 255, 0.05);
+      --zen-subtle: rgba(255,255,255,0.1);
     }
   }
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -12,6 +12,7 @@ export default {
         paper: 'var(--zen-paper)',
         coral: '#F76F53',
         dark: 'var(--zen-dark)',
+        subtle: 'var(--zen-subtle)',
         muted: 'var(--zen-muted)',
         'zen-blue': '#6287f5',
         'zen-green': '#63f78b',


### PR DESCRIPTION
I've replaced the almost invisible background color for buttons with a subtle one which is the same as `feature.astro` section.

To change the color, just edit the values in the `layout.astro`.

Before:
![image](https://github.com/user-attachments/assets/57ac1133-a3c0-47b0-bcbf-4fb1e427fe5b)

Now:
![image](https://github.com/user-attachments/assets/dd66b9b0-0b60-47d3-8e98-1c4b7f4cac37)
