### PR TITLE
Design changes to release notes

### DIFF
--- a/src/components/ReleaseNoteItem.astro
+++ b/src/components/ReleaseNoteItem.astro
@@ -14,10 +14,10 @@ if (props.date) {
 ---
 
 <section
-  class="release-note-item relative mt-24 flex flex-col border-t pt-24 lg:flex-row"
+  class="release-note-item md:max-w-full overflow-y-hidden relative mt-24 flex flex-col border-t pt-24"
   id={props.version}
 >
-  <div class="px-5 md:px-10 md:pr-32">
+  <div class="px-5 md:px-10 md:pr-32 flex flex-col gap-8">
     {
       isTwilight ? (
         <a
@@ -28,20 +28,23 @@ if (props.date) {
         </a>
       ) : null
     }
-    <h1 class="text-3xl font-bold">
-      {
-        isTwilight ? (
-          <>Twilight changes for {props.version} 🌙</>
-        ) : (
-          <>Release notes for {props.version} 🎉</>
-        )
-      }
-    </h1>
-    {date && date.toLocaleDateString('en-US', { dateStyle: 'long' })}
-    <div class="mt-2">
+    <div class="flex flex-col lg:items-end lg:flex-row">
+      <h1 class="text-3xl font-bold">
+        {
+          isTwilight ? (
+            <>Twilight changes for {props.version} 🌙</>
+          ) : (
+            <>Release notes for {props.version} 🎉</>
+          )
+        }
+      </h1>
+      <p class="lg:ml-auto">{date && date.toLocaleDateString('en-US', { dateStyle: 'long' })}</p>
+    </div>
+    
+    <div class="">
       <a
         rel="noopener noreferrer"
-        class="whitespace-nowrap text-sm text-coral opacity-60"
+        class="whitespace-nowrap text-sm text-coral opacity-70 underline underline-offset-4"
         target="_blank"
         href={`https://github.com/zen-browser/desktop/releases/tag/${isTwilight ? 'twilight' : props.version}`}
         >GitHub Release</a
@@ -52,7 +55,7 @@ if (props.date) {
             <span class="text-muted-foreground mx-auto">•</span>
             <a
               rel="noopener noreferrer"
-              class="whitespace-nowrap text-sm text-coral opacity-60"
+              class="whitespace-nowrap text-sm text-coral opacity-70 underline underline-offset-4"
               target="_blank"
               href={`https://github.com/zen-browser/desktop/actions/runs/${props.workflowId}`}
             >
@@ -62,7 +65,7 @@ if (props.date) {
         ) : null
       }
     </div>
-    <div class="text-muted-forground mt-6 flex text-sm opacity-70">
+    <div class="text-muted-forground flex text-sm opacity-70">
       {isTwilight ? <Info class="mx-4 my-0 size-6 text-yellow-500" /> : null}
       <p class="m-0">
         {
@@ -77,20 +80,20 @@ if (props.date) {
           rel="noopener noreferrer"
           target="_blank"
           href="https://github.com/zen-browser/desktop/issues/"
-          class="text-underline text-coral">the issues page</a
+          class="text-underline text-coral underline underline-offset-4">the issues page</a
         >.
       </p>
     </div>
 
     {
       props.extra ? (
-        <p class="text-md text-muted-foreground extra mt-2">
+        <p class="text-md text-muted-foreground extra">
           <Fragment set:html={props.extra.replace(/\n/g, '<br />')} />
         </p>
       ) : null
     }
-    <div class="mt-8" data-orientation="vertical"></div>
-    <Accordion>
+    <div class="" data-orientation="vertical"></div>
+    <Accordion class="px-3 rounded-lg border-2 border-dark">
       {
         props.fixes ? (
           <AccordionItem title="Fixes">

--- a/src/pages/release-notes/index.astro
+++ b/src/pages/release-notes/index.astro
@@ -14,12 +14,12 @@ import Description from '../../components/Description.astro'
       class="py-42 flex min-h-screen flex-col justify-center px-10 lg:px-10 xl:px-10 2xl:w-3/5"
     >
       <Description class="mt-48 text-4xl font-bold">Release Notes</Description>
-      <p class="text-base opacity-55">
+      <p class="text-base opacity-70">
         Stay up to date with the latest changes to Zen Browser! Since the <a
-          class="text-coral"
+          class="text-coral underline underline-offset-4"
           href="#1.0.0-a.1">first release</a
         > till <a
-          class="text-coral"
+          class="text-coral underline underline-offset-4"
           href={`/release-notes#${releaseNotes[0].version}`}
           >{releaseNotes[0].version}</a
         >, we've been working hard to make Zen Browser the best it can be.


### PR DESCRIPTION
This PR has multiple design changes for the release notes page.

1. Added a border around the accordion items. The border is consistent with other borders on the website (like navbar dropdown and mods page, etc)
2. Decreased the opacity on some text elements to make them stand out more.
3. Added underlines to href/redirects (with offsets) to make them more noticable.
4. Moved the date of the release to the right side of the release note item (except for mobile because there's no space).
5. Redone spacing so that it relies on flexbox gap instead of margins, so all are equally apart. The spacing is also increased.

Old:

![{E6C52E44-CD8F-43DD-97C8-684646A0DC61}](https://github.com/user-attachments/assets/5243ee79-57b3-4ad1-baa3-dc62d2c5c5bb)

New:

![{7BE61DAF-3C07-4A9E-96F7-17A13ECBCE8B}](https://github.com/user-attachments/assets/ce725733-23a0-4175-ad99-81e4e33927a1)

With accordion opened:

![{A0624189-015F-4011-9318-C38C697ABC9E}](https://github.com/user-attachments/assets/b770a27c-43ae-4256-89ee-08665ddfa09a)