### PR TITLE
feat: include mod homepage link

### DIFF
--- a/src/pages/mods/[...slug].astro
+++ b/src/pages/mods/[...slug].astro
@@ -77,6 +77,18 @@ const dates = {
               </p>
             )
           }
+          {
+            mod.homepage && (
+              <a
+                href={mod.homepage}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="underline"
+              >
+                Visit mod homepage
+              </a>
+            )
+          }
         </div>
         <div class="flex flex-col sm:items-end">
           <Button


### PR DESCRIPTION
Since the mods page does not show much useful information about individual mods, it might be useful for most users to be able to visit the mods' homepage and view the details before installing. Mod home page links are already optionally available in [`ThemeAPI`](https://github.com/zen-browser/www/blob/20e516f62abe4db7c541e189b6a67bbb8dd987d7/src/mods.ts#L3C18-L18). 

![sshot](https://github.com/user-attachments/assets/d06de501-4754-4458-bd69-0bfc54255b1f)
