### PR TITLE
Fix layout on welcome page

### DIFF
--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -161,8 +161,8 @@ const {
     </div>
   </div>
 </section>
-<section id="sponsors" class="px-4 lg:flex-row lg:px-12 lg:py-32 xl:px-24">
-  <div class="mx-auto flex flex-col px-6 lg:w-1/2 lg:px-0 lg:text-center">
+<section id="sponsors" class="mb-32 px-4">
+  <div class="mx-auto flex flex-col px-6 text-center">
     <motion.span client:load {...getTitleAnimation(0.2)}>
       <Description class="mb-2 px-4 text-6xl font-bold"
         >Our Sponsors</Description

--- a/src/pages/welcome.astro
+++ b/src/pages/welcome.astro
@@ -5,7 +5,7 @@ import Features from '../components/Features.astro'
 
 <Layout title="Welcome!">
   <main
-    class="relative mx-auto flex flex-col items-center gap-24 px-6 lg:px-24 xl:flex-row"
+    class="relative mx-auto flex flex-col items-center gap-24 px-6 lg:gap-0 lg:px-24"
   >
     <Features title1="Welcome" title2="to" title3="Zen!" />
   </main>


### PR DESCRIPTION
## Because
The *Features* section and the new *Sponsors* section were placed alongside each other on large screens.

<details>
<summary>Initial Layout</summary>

![image](https://github.com/user-attachments/assets/a2b587e2-eeea-444d-93a2-4961dc26d207)
</details>

## This PR
- Places the Sponsor section below the Features section, with reasonable spacing between them.

<details>
<summary>Updated Layout</summary>

![image](https://github.com/user-attachments/assets/e34dd791-d866-428e-bfdd-b4b65fbb354d)
</details>

## Issue
Tries to fix #527 

## Additional Information
I am unsure whether the initial layout was intentional (maybe for sponsor visibility?). In that case, additional layout changes would need to be made to have a consistent look with the side-by-side sections.

P.S. The above screenshots are in 1536x864 for demonstration purposes. The initial layout looks kind of alright in 1920x1080.
