### PR TITLE
Plaintext link theming unification & misc

### DIFF
--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -174,7 +174,7 @@ const {
         We are grateful to our sponsors for their support. They help us to keep
         the project alive.<br />You can also be part of this journey by donating <a
           href="/donate"
-          class="text-coral">here</a
+          class="zen-link">here</a
         >!
       </Description>
     </motion.span>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -124,7 +124,7 @@ import { ArrowRight } from 'lucide-astro'
       <p class="flex justify-center gap-2 lg:justify-start">
         Made with <span aria-label="love">❤️</span> by the <a
           href="/about"
-          class="inline-block font-bold">Zen Team</a
+          class="inline-block font-bold zen-link">Zen Team</a
         >
       </p>
     </section>

--- a/src/components/ReleaseNoteItem.astro
+++ b/src/components/ReleaseNoteItem.astro
@@ -41,7 +41,7 @@ if (props.date) {
     <div class="mt-2">
       <a
         rel="noopener noreferrer"
-        class="whitespace-nowrap text-sm text-coral opacity-60"
+        class="whitespace-nowrap text-sm zen-link opacity-60"
         target="_blank"
         href={`https://github.com/zen-browser/desktop/releases/tag/${isTwilight ? 'twilight' : props.version}`}
         >GitHub Release</a
@@ -52,7 +52,7 @@ if (props.date) {
             <span class="text-muted-foreground mx-auto">•</span>
             <a
               rel="noopener noreferrer"
-              class="whitespace-nowrap text-sm text-coral opacity-60"
+              class="whitespace-nowrap text-sm zen-link opacity-60"
               target="_blank"
               href={`https://github.com/zen-browser/desktop/actions/runs/${props.workflowId}`}
             >
@@ -77,7 +77,7 @@ if (props.date) {
           rel="noopener noreferrer"
           target="_blank"
           href="https://github.com/zen-browser/desktop/issues/"
-          class="text-underline text-coral">the issues page</a
+          class="zen-link">the issues page</a
         >.
       </p>
     </div>
@@ -103,15 +103,17 @@ if (props.date) {
                     <>
                       {fix.description}
                       {fix.issue ? (
-                        <a
-                          class="text-coral"
+                        <>
+                          {' '}
+                          <a
+                          class="zen-link"
                           href={`https://github.com/zen-browser/desktop/issues/${fix.issue}`}
                           rel="noopener noreferrer"
                           target="_blank"
                           aria-label={`View issue number ${fix.issue} on GitHub`}
-                        >
-                          #{fix.issue}
-                        </a>
+                          >#{fix.issue}
+                          </a>
+                        </>
                       ) : null}
                     </>
                   )}
@@ -155,7 +157,7 @@ if (props.date) {
                     <>
                       {breakingChange.description}
                       <a
-                        class="text-coral"
+                        class="zen-link"
                         href={breakingChange.link}
                         rel="noopener noreferrer"
                         target="_blank"
@@ -208,7 +210,7 @@ if (props.date) {
 
     .extra {
       & a {
-        @apply !text-coral;
+        @apply !text-coral underline underline-offset-4;
       }
     }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -158,6 +158,10 @@ import MobileNavBar from '../components/MobileNavBar'
     font-feature-settings: 'swsh' 0;
     font-style: normal;
   }
+
+  .zen-link {
+    @apply text-coral underline underline-offset-4;
+  }
 </style>
 <style is:global>
   /* Declare a custom CSS class to make the icon look right */

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -37,7 +37,7 @@ import Layout from '../layouts/Layout.astro'
           <ul>
             <li class="text-sm">
               <a href="https://cheff.dev/"
-                ><strong class="font-bold underline">Mauro B.</strong></a
+                ><strong class="font-bold zen-link">Mauro B.</strong></a
               ><span class="opacity-60"> : Creator, Main Developer</span>
             </li>
             <li class="mt-2 text-sm">
@@ -49,21 +49,21 @@ import Layout from '../layouts/Layout.astro'
             </li>
             <li class="mt-2 text-sm">
               <a href="https://janheres.eu/"
-                ><strong class="font-bold underline">Jan Heres</strong></a
+                ><strong class="font-bold zen-link">Jan Heres</strong></a
               ><span class="opacity-60">
                 : Active contributor and helps with MacOS builds</span
               >
             </li>
             <li class="mt-2 text-sm">
               <a href="https://github.com/BrhmDev"
-                ><strong class="font-bold underline">BrhmDev</strong></a
+                ><strong class="font-bold zen-link">BrhmDev</strong></a
               ><span class="opacity-60">
                 : Active contributor with great contributions</span
               >
             </li>
             <li class="mt-2 text-sm">
               <a href="https://thatcanoa.org/"
-                ><strong class="font-bold underline">Canoa</strong></a
+                ><strong class="font-bold zen-link">Canoa</strong></a
               ><span class="opacity-60">
                 : Active contributor, and very active in issue handling and
                 website management</span
@@ -71,37 +71,37 @@ import Layout from '../layouts/Layout.astro'
             </li>
             <li class="mt-2 text-sm">
               <a href="https://cybrneon.xyz/"
-                ><strong class="font-bold underline">Adam</strong></a
+                ><strong class="font-bold zen-link">Adam</strong></a
               ><span class="opacity-60"> : Branding and design</span>
             </li>
             <li class="mt-2 text-sm">
               <a href="https://github.com/kristijanribaric"
-                ><strong class="font-bold underline">kristijanribaric</strong
+                ><strong class="font-bold zen-link">kristijanribaric</strong
                 ></a
               ><span class="opacity-60"> : Active contributor</span>
             </li>
             <li class="mt-2 text-sm">
               <a href="https://github.com/n7itro"
-                ><strong class="font-bold underline">n7itro</strong></a
+                ><strong class="font-bold zen-link">n7itro</strong></a
               ><span class="opacity-60">
                 : Active contributor and release notes writer</span
               >
             </li>
             <li class="mt-2 text-sm">
               <a href="https://josuegalre.netlify.app/"
-                ><strong class="font-bold underline">Bryan Galdámez</strong></a
+                ><strong class="font-bold zen-link">Bryan Galdámez</strong></a
               ><span class="opacity-60">
                 : Huge contributor on theme functionalities</span
               >
             </li>
             <li class="mt-2 text-sm">
               <a href="https://iamjafeth.com/"
-                ><strong class="font-bold underline">Jafeth Garro</strong></a
+                ><strong class="font-bold zen-link">Jafeth Garro</strong></a
               ><span class="opacity-60"> : Documentation writer</span>
             </li>
             <li class="mt-2 text-sm">
               <a href="https://github.com/LarveyOfficial/"
-                ><strong class="font-bold underline">Larvey</strong></a
+                ><strong class="font-bold zen-link">Larvey</strong></a
               ><span class="opacity-60"> : AUR maintainer</span>
             </li>
             <li class="mt-2 text-sm">

--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -200,7 +200,7 @@ const githubIcon = icon({ prefix: 'fab', iconName: 'github' })
             antivirus, please
             <a
               href="https://github.com/zen-browser/desktop/issues/new/choose"
-              class="text-accent ml-1 underline">report it to us</a
+              class="text-accent ml-1 zen-link">report it to us</a
             >.
           </p>
         </div>

--- a/src/pages/mods/[...slug].astro
+++ b/src/pages/mods/[...slug].astro
@@ -63,9 +63,9 @@ const dates = {
         class="h-full w-full rounded-xl border-2 border-dark object-cover shadow"
       />
       <div class="flex flex-col justify-between gap-2 sm:flex-row">
-        <div class="flex-shrink-0 font-normal">
+        <div class="flex flex-col gap-2 flex-shrink-0 font-normal">
           <p>
-            Created by <a href={getAuthorLink(mod.author)} class="font-bold"
+            Created by <a href={getAuthorLink(mod.author)} class="font-bold zen-link"
               >@{mod.author}</a
             > • <span class="font-bold">v{mod.version}</span>
           </p>
@@ -83,7 +83,7 @@ const dates = {
                 href={mod.homepage}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="underline"
+                class="zen-link"
               >
                 Visit mod homepage
               </a>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -43,7 +43,9 @@ import Layout from '../layouts/Layout.astro'
       However, you can opt-in to share telemetry data to Mozilla for the
       improvement of FireFox (the base upon which the Zen Browser is built). It
       will be treated in accordance with their Privacy Policy which you can read
-      about <a href="https://www.mozilla.org/en-US/privacy/">here</a>.
+      about <a
+        class="zen-link"
+        href="https://www.mozilla.org/en-US/privacy/">here</a>.
     </p>
     <h3 class="mt-4 text-xl !font-bold" id="-1-2-no-personal-data-collection-">
       <strong class="font-bold">1.2. No Personal Data Collection</strong>
@@ -108,12 +110,15 @@ import Layout from '../layouts/Layout.astro'
     </p>
     <ul>
       <li>
-        <a href="https://www.mozilla.org/en-US/privacy/mozilla-accounts/"
+        <a
+          class="zen-link"
+          href="https://www.mozilla.org/en-US/privacy/mozilla-accounts/"
           >Mozilla Firefox Sync</a
         >
       </li>
       <li>
         <a
+          class="zen-link"
           href="https://support.mozilla.org/en-US/kb/how-firefox-securely-saves-passwords#:~:text=Firefox%20Desktop%20encrypts%20your%20passwords,cryptography%20to%20obscure%20your%20passwords."
           >This is how we store your passwords</a
         >
@@ -202,7 +207,9 @@ import Layout from '../layouts/Layout.astro'
     </p>
     <ul>
       <li>
-        Please check <a href="https://www.mozilla.org/en-US/privacy/"
+        Please check <a
+          class="zen-link"
+          href="https://www.mozilla.org/en-US/privacy/"
           >Firefox Privacy Notice</a
         > for more information.
       </li>
@@ -216,11 +223,15 @@ import Layout from '../layouts/Layout.astro'
     </p>
     <ul>
       <li>
-        Discord: <a href="https://discord.gg/zen-browser"
+        Discord: <a
+          class="zen-link"
+          href="https://discord.gg/zen-browser"
           >Zen Browser&#39;s Discord</a
         >
       </li>
-      <li>GitHub: <a href="https://github.com/zen-browser">Organization</a></li>
+      <li>GitHub: <a 
+        class="zen-link"
+        href="https://github.com/zen-browser">Organization</a></li>
     </ul>
   </main>
 </Layout>
@@ -236,9 +247,5 @@ import Layout from '../layouts/Layout.astro'
 
   li {
     @apply ml-4 list-disc;
-  }
-
-  a {
-    @apply text-coral;
   }
 </style>

--- a/src/pages/release-notes/index.astro
+++ b/src/pages/release-notes/index.astro
@@ -18,10 +18,10 @@ import Button from '../../components/Button.astro'
       <Description class="mt-48 text-4xl font-bold">Release Notes</Description>
       <p class="text-base opacity-55">
         Stay up to date with the latest changes to Zen Browser! Since the <a
-          class="text-coral"
+          class="zen-link"
           href="#1.0.0-a.1">first release</a
         > till <a
-          class="text-coral"
+          class="zen-link"
           href={`/release-notes#${releaseNotes[0].version}`}
           >{releaseNotes[0].version}</a
         >, we've been working hard to make Zen Browser the best it can be.


### PR DESCRIPTION
This PR unifies hyperlinks on plaintext throughout the website. The current website uses a mix of coral text and just an underline depending on where you look. The privacy policy and release notes use coral text while the mod page, download page, and contributor page use just an underline.

1. Creates a universal 'zen-link' class that applies 'text-coral underline underline-offset-4' classes.
2. Applied this class to all the necessary areas in the website. The only elements it doesn't apply to are the logo at the top-left, image redirects and buttons, of course. Any other usage of plaintext hyperlinks have the 'zen-link' class.

The PR also adjusts the spacing on the mod slug page of the info section:

(old)
![{1276E1D2-AFAD-4AFD-860F-AC9D519323C5}](https://github.com/user-attachments/assets/63dfc5b5-f278-4a99-b134-4fc43e1ce7d8)

(new)
![{FE1FD6CA-2043-40D2-A9C5-C54FFFDB1A89}](https://github.com/user-attachments/assets/4c2ae667-d9bc-47ea-bfe0-e43493c1e3d3)


here are some images of the hyperlink changes throughout the site:

![{4B292FF4-8505-4362-A59D-D2AFF797DA6C}](https://github.com/user-attachments/assets/5d1cb797-6d34-4fa3-a508-8fe1f227379e)

![{D4B361A5-067F-4F08-8261-B4D03730B7B3}](https://github.com/user-attachments/assets/2defc8d7-0c44-444f-8c72-39a9f97f0813)

![{C0FFE748-4796-4191-84F0-CF03CC2DC971}](https://github.com/user-attachments/assets/4ebc0c0b-bba9-4c6a-805d-bafc3c46c176)

The main motivation for these changes are that the hyperlinks are inconsistent, and sometimes not obvious enough to be hyperlinks.