### PR TITLE
Improve LCP by making element slightly opaque

### DIFF
--- a/src/animations.ts
+++ b/src/animations.ts
@@ -1,6 +1,6 @@
 export function getTitleAnimation(delay = 0, duration = 0.3, once = true) {
   return {
-    initial: { opacity: 0, translateY: 20, filter: 'blur(4px)' },
+    initial: { opacity: 0.001, translateY: 20, filter: 'blur(4px)' },
     whileInView: {
       opacity: 1,
       translateY: 0,
@@ -13,7 +13,7 @@ export function getTitleAnimation(delay = 0, duration = 0.3, once = true) {
 
 export function getZoomInAnimation(delay = 0) {
   return {
-    initial: { scale: 0.8, opacity: 0 },
+    initial: { scale: 0.8, opacity: 0.001 },
     whileInView: { scale: 1, opacity: 1, transition: { duration: 0.2, delay } },
   }
 }


### PR DESCRIPTION
Improve LCP by making the LCP element technically (but not-visibly) opaque. This avoids LCP calculations waiting on the animation to play.

New (511.4 ms)
![image](https://github.com/user-attachments/assets/168b5f1e-bd00-4477-9186-202736f5b069)

Old (3,322.9 ms)
![image](https://github.com/user-attachments/assets/c479fbe1-3906-4606-9622-15323bdbadfb)

This isn't a "real performance improvement", but fixes the animation blocking the metric. There are other improvements to be made for LCP, but with this change we can understand if LCP is actually an issue for users, or not.