### PR TITLE
fix: hide empty accordions in release notes

### DIFF
--- a/src/components/ReleaseNoteItem.astro
+++ b/src/components/ReleaseNoteItem.astro
@@ -92,7 +92,7 @@ if (props.date) {
     <div class="mt-8" data-orientation="vertical"></div>
     <Accordion>
       {
-        props.fixes ? (
+        props.fixes?.length ? (
           <AccordionItem title="Fixes">
             <ul class="list-inside list-disc">
               {props.fixes.map((fix: any) => (
@@ -124,7 +124,7 @@ if (props.date) {
         ) : null
       }
       {
-        props.features ? (
+        props.features?.length ? (
           <AccordionItem title="Features">
             <ul class="list-inside list-disc">
               {props.features.map((feature: string) => (
@@ -135,7 +135,7 @@ if (props.date) {
         ) : null
       }
       {
-        props.themeChanges ? (
+        props.themeChanges?.length ? (
           <AccordionItem title="Theme Changes">
             <ul class="list-inside list-disc">
               {props.themeChanges.map((themeChange: string) => (
@@ -146,7 +146,7 @@ if (props.date) {
         ) : null
       }
       {
-        props.breakingChanges ? (
+        props.breakingChanges?.length ? (
           <AccordionItem title="Breaking Changes">
             <ul class="list-inside list-disc">
               {props.breakingChanges.map((breakingChange: BreakingChange) => (


### PR DESCRIPTION
## Changes
- Added null checks with optional chaining for all release note sections

Sections (Features, Fixes, Theme Changes, Breaking Changes) only render when they contain items.
Improves UI clarity by removing empty accordions.

![image](https://github.com/user-attachments/assets/882b59d6-de6c-4d6b-9d75-ccd678ac0ee9)
