### PR TITLE
Fixed recent video update broke layout with video

### DIFF
--- a/src/components/Video.astro
+++ b/src/components/Video.astro
@@ -3,38 +3,14 @@ const { src, class: className, ...rest } = Astro.props
 const type = src.split('.').pop() || 'webm'
 ---
 
-<div class="video-container">
-  <div class="video-placeholder"></div>
-  <video
-    class:list={['w-fit', className]}
-    data-src={src}
-    preload="none"
-    {...rest}
-  >
-    <source src="" type={`video/${type}`} />
-  </video>
-</div>
-
-<style>
-  .video-container {
-    position: relative;
-    width: 100%;
-  }
-
-  .video-placeholder {
-    width: 100%;
-    height: 100%;
-    z-index: 1;
-  }
-
-  video[data-src] + .video-placeholder {
-    display: block;
-  }
-
-  video:not([data-src]) + .video-placeholder {
-    display: none;
-  }
-</style>
+<video
+  class:list={['w-fit', className]}
+  data-src={src}
+  preload="none"
+  {...rest}
+>
+  <source src="" type={`video/${type}`} />
+</video>
 
 <script>
   const videos = document.querySelectorAll(
@@ -48,10 +24,6 @@ const type = src.split('.').pop() || 'webm'
       source.src = dataSrc
       video.removeAttribute('data-src')
       video.load()
-      const placeholder = video.previousElementSibling as HTMLElement
-      if (placeholder) {
-        placeholder.style.display = 'none'
-      }
     }
   }
 


### PR DESCRIPTION
The PR from few days ago seemed to have broken positioning of the videos on certain situations, so I have deleted regarding changes.
Also, as we are no longer dynamically loading the video as user scrolls, mobile users might be suffering from loading 6 videos on the landing page.
Please let me know if anyone has better ideas to defer loading videos without making the site laggy.