### PR TITLE
docs(download): clarify OS requirements and installer choices

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -106,7 +106,7 @@ const githubIcon = icon({ prefix: 'fab', iconName: 'github' })
           platform="mac"
           icon={appleIcon.html}
           title="MacOS Download"
-          description="Universal binary for Apple Silicon (M1/M2/M3) and Intel Macs.<br />Requires macOS 11.0 or later."
+          description="Works on both new Apple (M-Series) and older Intel Macs.<br />Requires macOS 11.0 or later."
           releases={releases.macos}
         />
         <!-- Windows Download -->
@@ -114,7 +114,7 @@ const githubIcon = icon({ prefix: 'fab', iconName: 'github' })
           platform="windows"
           icon={windowsIcon.html}
           title="Windows Download"
-          description="For Windows 10 and Windows 11.<br />If you're unsure which one to download, the 64-bit installer is the recommended choice for most users."
+          description="Works on Windows 10 and Windows 11.<br />Not sure which version to get? Most people should choose the 64-bit installer."
           releases={releases.windows}
         />
 
@@ -123,7 +123,7 @@ const githubIcon = icon({ prefix: 'fab', iconName: 'github' })
           platform="linux"
           icon={linuxIcon.html}
           title="Linux Download"
-          description="Available in multiple formats for different Linux distributions. Choose the option that best fits your system."
+          description="Works with many Linux versions.<br />Pick the download that matches your system."
           releases={releases.linux}
         />
       </div>


### PR DESCRIPTION
Updated the download.astro page to make platform compatibility and installer choices clearer for non-technical users. Reworded text for macOS, Windows, and Linux sections.