### PR TITLE
fix: fixes inconsistent mod item image height

### DIFF
--- a/src/components/ModsList.tsx
+++ b/src/components/ModsList.tsx
@@ -193,7 +193,7 @@ export default function ModsList({ mods }: ModsListProps) {
               href={`/mods/${mod.id}`}
               className="flex flex-col gap-4 border-transparent transition-colors duration-100 hover:opacity-90"
             >
-              <div className="relative mb-0 block aspect-[1.85/1] h-48 overflow-hidden rounded-md border-2 border-dark object-cover shadow-md lg:h-auto">
+              <div className="relative mb-0 block aspect-[1.85/1] h-48 overflow-hidden rounded-md border-2 border-dark object-cover shadow-md">
                 <img
                   src={mod.image}
                   alt={mod.name}


### PR DESCRIPTION
This fixes a change introduced in #512 where image containers for the mods page was set to "h-auto". The contributor intended this for ultra-large screens, which you can't see the issue on, but you see it on regular screens:

![{AAFBF933-8923-460B-94DF-89E1F3CB5ADD}](https://github.com/user-attachments/assets/76726876-502e-4cde-86a7-2390cf33f283)
Above is the current live site. Notice the first mod in the list has a smaller, inconsistent image height. In the PR that made this happen, the contributor probably didn't check for regular screens, because using "h-auto" here wouldn't show this behavior on ultra-large screens. It's not visible in the screenshot above, but most of the heights are actually inconsistent. Some are a few pixels off, others are almost a hundred pixels off. Here's what this PR looks like:

![{F66245E0-E348-445C-B3FF-2B9CE4243D9D}](https://github.com/user-attachments/assets/add11a58-5108-40d9-948b-a52e8c724cb6)