### PR TITLE
Fix Hero component text

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -19,14 +19,6 @@ function getNewAnimationDelay() {
 function getHeroTitleAnimation() {
   return getTitleAnimation(getNewAnimationDelay())
 }
-
-const {
-  title1 = 'welcome',
-  title2 = 'to',
-  title3 = 'a',
-  title4 = 'calmer',
-  title5 = 'internet',
-} = Astro.props
 ---
 
 <header
@@ -38,24 +30,24 @@ const {
       class="relative px-12 text-center !font-normal !leading-8 leading-[108px] md:!text-7xl lg:px-0 lg:!text-9xl"
     >
       <motion.span client:load {...getHeroTitleAnimation()}>
-        {title1}
+        {'welcome'}
       </motion.span>
       <motion.span client:load {...getHeroTitleAnimation()}>
-        {title2}
+        {'to'}
       </motion.span>
       <br class="hidden md:block" />
       <motion.span client:load {...getHeroTitleAnimation()}>
-        {title3}
+        {'a'}
       </motion.span>
       <motion.span
         client:load
         {...getHeroTitleAnimation()}
         className="italic text-coral"
       >
-        {title4}
+        {'calmer'}
       </motion.span>
       <motion.span client:load {...getHeroTitleAnimation()}>
-        {title5}
+        {'internet'}
       </motion.span>
     </Title>
     <motion.span client:load {...getHeroTitleAnimation()}>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -19,6 +19,14 @@ function getNewAnimationDelay() {
 function getHeroTitleAnimation() {
   return getTitleAnimation(getNewAnimationDelay())
 }
+
+const {
+  title1 = 'welcome',
+  title2 = 'to',
+  title3 = 'a',
+  title4 = 'calmer',
+  title5 = 'internet',
+} = Astro.props
 ---
 
 <header
@@ -30,20 +38,24 @@ function getHeroTitleAnimation() {
       class="relative px-12 text-center !font-normal !leading-8 leading-[108px] md:!text-7xl lg:px-0 lg:!text-9xl"
     >
       <motion.span client:load {...getHeroTitleAnimation()}>
-        welcome
+        {title1}
       </motion.span>
-      <motion.span client:load {...getHeroTitleAnimation()}> to </motion.span>
+      <motion.span client:load {...getHeroTitleAnimation()}>
+        {title2}
+      </motion.span>
       <br class="hidden md:block" />
-      <motion.span client:load {...getHeroTitleAnimation()}> a </motion.span>
+      <motion.span client:load {...getHeroTitleAnimation()}>
+        {title3}
+      </motion.span>
       <motion.span
         client:load
         {...getHeroTitleAnimation()}
         className="italic text-coral"
       >
-        calmer
+        {title4}
       </motion.span>
       <motion.span client:load {...getHeroTitleAnimation()}>
-        internet
+        {title5}
       </motion.span>
     </Title>
     <motion.span client:load {...getHeroTitleAnimation()}>


### PR DESCRIPTION
So, I opened the website and saw this giant gap between "calmer" and "internet":
![image](https://github.com/user-attachments/assets/8149d2e2-ece8-424b-b706-4913988e6aa9)

Looking into the codebase and figured out that it happens because of code formatting, so according to the similar solution in "Features", I made changes in Hero

Result:
![image](https://github.com/user-attachments/assets/332a65b1-0c62-4eeb-8933-e6d28892bb93)
