### PR TITLE
fix(modal): fixed release modal preventing scroll when closed with `esc`

### DIFF
--- a/src/pages/[...locale]/release-notes/index.astro
+++ b/src/pages/[...locale]/release-notes/index.astro
@@ -130,6 +130,14 @@ const {
   window.addEventListener('scroll', toggleScrollButton)
   versionButton?.addEventListener('click', openVersionModal)
   versionList?.addEventListener('click', navigateToVersion)
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal?.hasAttribute('open')) {
+      closeModal(modal)
+      // Remove scroll lock if present
+      document.body.style.overflow = ''
+    }
+  })
 </script>
 
 <style is:global>


### PR DESCRIPTION
Fixes an issue where closing the release notes modal with the Escape key would leave the page unscrollable until the user clicks. Now, pressing Escape to close the modal will also restore body scroll, ensuring a smooth user experience.

Closes #604 