### PR TITLE
feat(codeowners): add codeowner to support auto assigning reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mauro-balades 


### PR DESCRIPTION
This will let us automatically assign reviewer.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.