### PR TITLE
feat: language selection dropdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   "eslint.format.enable": false,
   "prettier.requireConfig": true,
   "[astro]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "astro-build.astro-vscode"
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/src/components/I18nSwitch.astro
+++ b/src/components/I18nSwitch.astro
@@ -1,0 +1,66 @@
+---
+import { Dropdown, DropdownItems } from 'astro-navbar'
+import LanguagesIcon from '~/icons/Languages.astro'
+import { getLocale, getPath, getUI } from '~/utils/i18n'
+
+const locale = getLocale(Astro)
+const getLocalePath = getPath(locale)
+
+const {
+  components: {
+    nav: { menu },
+  },
+} = getUI(locale)
+
+interface Props {
+  label?: string
+  className?: string
+}
+
+const { label, className = '' } = Astro.props
+---
+
+<Dropdown class="group">
+  <button
+    type="button"
+    class:list={['inline-flex h-8 w-8 cursor-pointer items-center justify-center', className]}
+    id="i18n-switcher"
+    aria-label={label || 'Toggle i18n'}
+  >
+    <LanguagesIcon />
+  </button>
+  <DropdownItems>
+    <div class="navbar-dropdown !grid-cols-1 gap-1">
+      <a class="dropdown-item" href={Astro.url.pathname.replace(/^\/ja\//, '/')}>
+        <div class="dropdown-title">English</div>
+      </a>
+      <a
+        class="dropdown-item"
+        href={Astro.url.pathname.startsWith('/ja')
+          ? Astro.url.pathname
+          : `/ja${Astro.url.pathname}`}
+      >
+        <div class="dropdown-title">日本語</div>
+      </a>
+    </div>
+  </DropdownItems>
+</Dropdown>
+
+<script></script>
+
+<style>
+  .navbar-dropdown {
+    @apply absolute mt-2 grid !-translate-x-1/2 !transform grid-cols-2 gap-2 rounded-lg border-2 border-dark bg-paper p-3 shadow-sm;
+    & .dropdown-item {
+      @apply flex cursor-pointer select-none flex-col gap-1 rounded-lg p-3 pl-8 transition-colors duration-200;
+
+      &:hover {
+        @apply bg-muted;
+      }
+
+      & .dropdown-title {
+        @apply text-right font-bold;
+      }
+    }
+  }
+</style>

--- a/src/components/I18nSwitch.astro
+++ b/src/components/I18nSwitch.astro
@@ -1,52 +1,37 @@
 ---
 import { Dropdown, DropdownItems } from 'astro-navbar'
+import { i18n } from '~/constants/i18n'
 import LanguagesIcon from '~/icons/Languages.astro'
-import { getLocale, getPath, getUI } from '~/utils/i18n'
 
-const locale = getLocale(Astro)
-const getLocalePath = getPath(locale)
-
-const {
-  components: {
-    nav: { menu },
-  },
-} = getUI(locale)
-
-interface Props {
-  label?: string
-  className?: string
+function getHref(locale: string) {
+  if (locale === 'en') return Astro.url.pathname.replace(/^\/ja\//, '/')
+  if (locale === 'ja')
+    return Astro.url.pathname.startsWith('/ja') ? Astro.url.pathname : `/ja${Astro.url.pathname}`
+  return Astro.url.pathname
 }
-
-const { label, className = '' } = Astro.props
 ---
 
 <Dropdown class="group">
   <button
     type="button"
-    class:list={['inline-flex h-8 w-8 cursor-pointer items-center justify-center', className]}
+    class:list={['inline-flex h-8 w-8 cursor-pointer items-center justify-center']}
     id="i18n-switcher"
-    aria-label={label || 'Toggle i18n'}
+    aria-label={'Toggle i18n'}
   >
     <LanguagesIcon />
   </button>
   <DropdownItems>
     <div class="navbar-dropdown !grid-cols-1 gap-1">
-      <a class="dropdown-item" href={Astro.url.pathname.replace(/^\/ja\//, '/')}>
-        <div class="dropdown-title">English</div>
-      </a>
-      <a
-        class="dropdown-item"
-        href={Astro.url.pathname.startsWith('/ja')
-          ? Astro.url.pathname
-          : `/ja${Astro.url.pathname}`}
-      >
-        <div class="dropdown-title">日本語</div>
-      </a>
+      {
+        i18n.LOCALES.map(locale => (
+          <a class="dropdown-item" href={getHref(locale.value)} aria-label={locale.label}>
+            <div class="dropdown-title">{locale.label}</div>
+          </a>
+        ))
+      }
     </div>
   </DropdownItems>
 </Dropdown>
-
-<script></script>
 
 <style>
   .navbar-dropdown {

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -32,7 +32,7 @@ const {
     <div
       class="absolute left-1/2 hidden -translate-x-1/2 items-center gap-6 text-xs sm:text-sm lg:flex lg:text-base"
     >
-      <Dropdown class="group">
+      <Dropdown class="group relative">
         <button class="flex items-center">
           <span>{menu.gettingStarted}</span>
           <ChevronDownIcon
@@ -66,7 +66,7 @@ const {
           </div>
         </DropdownItems>
       </Dropdown>
-      <Dropdown class="group">
+      <Dropdown class="group relative">
         <button class="flex items-center">
           <span>{menu.usefulLinks}</span>
           <ChevronDownIcon
@@ -74,7 +74,7 @@ const {
           />
         </button>
         <DropdownItems>
-          <div class="navbar-dropdown !grid-cols-1 gap-1">
+          <div class="navbar-dropdown !min-w-[400px] !grid-cols-1 gap-1">
             <a class="dropdown-item" href={getLocalePath('/donate')}>
               <div class="dropdown-title">{menu.donate}</div>
               <div class="dropdown-description">
@@ -139,7 +139,7 @@ const {
 
 <style>
   .navbar-dropdown {
-    @apply absolute left-1/2 mt-2 grid !-translate-x-1/2 !transform grid-cols-2 gap-2 rounded-lg border-2 border-dark bg-paper p-3 shadow-sm;
+    @apply absolute left-1/2 z-10 mt-2 grid min-w-[600px] -translate-x-1/2 transform grid-cols-2 gap-2 rounded-lg border-2 border-dark bg-paper p-3 shadow-sm;
     & .dropdown-item {
       @apply flex cursor-pointer select-none flex-col gap-2 rounded-lg p-4 transition-colors duration-200;
 

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -108,10 +108,10 @@ const {
     </div>
     <div class="flex items-center gap-2 place-self-end lg:gap-4">
       <div id="i18n-switcher">
-        <I18nSwitch label="Toggle i18n" />
+        <I18nSwitch />
       </div>
       <div id="theme-switcher">
-        <ThemeSwitch label="Toggle theme" />
+        <ThemeSwitch />
       </div>
       <Button href="/download" class="hidden lg:flex" isPrimary>
         <span class="hidden items-center gap-2 lg:flex">

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -6,6 +6,7 @@ import ChevronDownIcon from '~/icons/ChevronDownIcon.astro'
 import DownloadIcon from '~/icons/DownloadIcon.astro'
 import MenuIcon from '~/icons/MenuIcon.astro'
 import { getLocale, getPath, getUI } from '~/utils/i18n'
+import I18nSwitch from './I18nSwitch.astro'
 import Logo from './Logo.astro'
 import MobileMenu from './MobileMenu.astro'
 import ThemeSwitch from './ThemeSwitch.astro'
@@ -106,6 +107,9 @@ const {
       </a>
     </div>
     <div class="flex items-center gap-2 place-self-end lg:gap-4">
+      <div id="i18n-switcher">
+        <I18nSwitch label="Toggle i18n" />
+      </div>
       <div id="theme-switcher">
         <ThemeSwitch label="Toggle theme" />
       </div>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -30,7 +30,7 @@ const {
       <span>{brand}</span>
     </a>
     <div
-      class="hidden items-center gap-6 place-self-center text-xs sm:text-sm lg:flex lg:text-base"
+      class="absolute left-1/2 hidden -translate-x-1/2 items-center gap-6 text-xs sm:text-sm lg:flex lg:text-base"
     >
       <Dropdown class="group">
         <button class="flex items-center">

--- a/src/components/ThemeSwitch.astro
+++ b/src/components/ThemeSwitch.astro
@@ -1,17 +1,8 @@
----
-interface Props {
-  label?: string
-  className?: string
-}
-
-const { label, className = '' } = Astro.props
----
-
 <button
   type="button"
-  class:list={['inline-flex h-8 w-8 cursor-pointer items-center justify-center', className]}
+  class:list={['inline-flex h-8 w-8 cursor-pointer items-center justify-center']}
   id="theme-switcher"
-  aria-label={label || 'Toggle theme'}
+  aria-label={'Toggle theme'}
 >
   <svg class="hidden h-5 w-5 dark:block" viewBox="0 0 24 24">
     <path

--- a/src/icons/Languages.astro
+++ b/src/icons/Languages.astro
@@ -1,0 +1,19 @@
+---
+const { class: className, ...props } = Astro.props
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class:list={['lucide lucide-languages-icon lucide-languages', className]}
+  {...props}
+  ><path d="m5 8 6 6"></path><path d="m4 14 6-6 2-3"></path><path d="M2 5h12"></path><path
+    d="M7 2h1"></path><path d="m22 22-5-10-5 10"></path><path d="M14 18h6"></path></svg
+>

--- a/src/pages/[...locale]/about.astro
+++ b/src/pages/[...locale]/about.astro
@@ -1,10 +1,10 @@
 ---
 import { Image } from 'astro:assets'
+import Button from '~/components/Button.astro'
 import Description from '~/components/Description.astro'
 import Layout from '~/layouts/Layout.astro'
 import { getLocale, getUI } from '~/utils/i18n'
 export { getStaticPaths } from '~/utils/i18n'
-import Button from '~/components/Button.astro'
 
 const locale = getLocale(Astro)
 


### PR DESCRIPTION
This PR adds a button to the header that allows users to select a language. With this, users can choose between English and Japanese and switch between them.
  
![image](https://github.com/user-attachments/assets/3e765435-0d8b-401f-9a06-fa50c8ab1009)
