### PR TITLE
fix: spelling mistake in twilight release notes

### DIFF
--- a/src/release-notes/twilight.json
+++ b/src/release-notes/twilight.json
@@ -12,6 +12,6 @@
     "Added a better custom color picker (experimental UI, might change)",
     "Improved and optimized glance animations and UI",
     "WebGPU is now enabled by default on windows",
-    "Added a mroe native feel to windows 11 window buttons"
+    "Added a more native feel to windows 11 window buttons"
   ]
 }


### PR DESCRIPTION
Changed "mroe" to "more" in twilights release notes