### PR TITLE
fix: Chrome OS only offered Mac download

### DIFF
--- a/src/components/download/DownloadScript.astro
+++ b/src/components/download/DownloadScript.astro
@@ -13,7 +13,7 @@
 
     if (os.name === 'Windows') {
       detectedOS = 'windows'
-    } else if (os.name === 'Linux' || os.name === 'Ubuntu') {
+    } else if (os.name === 'Linux' || os.name === 'Ubuntu' || os.name === 'Chrome OS') {
       detectedOS = 'linux'
     }
 


### PR DESCRIPTION
Linux is available on some Chromebooks, so is probably the better choice