### PR TITLE
fix: correct grammar in sponsors description - change 'donating us directly' to 'donating to us directly'. (#781)

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -44,7 +44,7 @@
       },
       "sponsors": {
         "title": "Our Sponsors",
-        "description": "We are grateful to our sponsors for their support. They help us to keep the project alive.<br />You can also be part of this journey by <a href=\"/donate\" class=\"zen-link\">donating us directly</a>!",
+        "description": "We are grateful to our sponsors for their support. They help us to keep the project alive.<br />You can also be part of this journey by <a href=\"/donate\" class=\"zen-link\">donating to us directly</a>!",
         "sponsors": {
           "tuta": {
             "name": "Tuta",


### PR DESCRIPTION
fix: changed the description of the text to be grammatically correct.