### PR TITLE
docs(www): fix homepage typo (closes #781)

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -44,7 +44,7 @@
       },
       "sponsors": {
         "title": "Our Sponsors",
-        "description": "We are grateful to our sponsors for their support. They help us to keep the project alive.<br />You can also be part of this journey by <a href=\"/donate\" class=\"zen-link\">donating us directly</a>!",
+        "description": "We are grateful to our sponsors for their support. They help us to keep the project alive.<br />You can also be part of this journey by <a href=\"/donate\" class=\"zen-link\">donating to us directly</a>!",
         "sponsors": {
           "tuta": {
             "name": "Tuta",


### PR DESCRIPTION
Fixed a typo on the homepage sponsors section.

Before: "donating us directly"
After: "donating to us directly"

Closes #781 