### PR TITLE
fix(release-notes):Twilight github release 404 fix using correct tag

### DIFF
--- a/src/components/ReleaseNoteItem.astro
+++ b/src/components/ReleaseNoteItem.astro
@@ -163,7 +163,7 @@ generateItems(props.knownIssues, 'known')
           rel="noopener noreferrer"
           class="zen-link whitespace-nowrap text-xs !no-underline opacity-80"
           target="_blank"
-          href={`https://github.com/zen-browser/desktop/releases/tag/${isTwilight ? 'twilight' : props.version}`}
+          href={`https://github.com/zen-browser/desktop/releases/tag/${isTwilight ? 'twilight-1' : props.version}`}
           >{releaseNoteItem.githubRelease}</a
         >
         {


### PR DESCRIPTION
Fixes #876

Twilight download and release note links were pointing to `/twilight` which doesn't exist. Updated to use the correct tag `twilight-1`.