### PR TITLE
fix: align release note and ESLint config types

### DIFF
--- a/.eslint/astro.ts
+++ b/.eslint/astro.ts
@@ -1,4 +1,4 @@
-import { type Linter } from 'eslint'
+import { ESLint, type Linter } from 'eslint'
 import jsxA11y from 'eslint-plugin-jsx-a11y'
 
 import { astroFiles } from './shared'
@@ -7,7 +7,7 @@ export const astroConfig: Linter.Config = {
   name: 'eslint/astro',
   files: astroFiles,
   plugins: {
-    'jsx-a11y': jsxA11y,
+    'jsx-a11y': jsxA11y as ESLint.Plugin,
   },
   rules: {
     // Astro specific adjustments

--- a/.eslint/import.ts
+++ b/.eslint/import.ts
@@ -1,5 +1,4 @@
 import { type Linter } from 'eslint'
-// @ts-expect-error - no types available
 import importPlugin from 'eslint-plugin-import'
 
 import { sharedFiles } from './shared'

--- a/.eslint/jsx-a11y.ts
+++ b/.eslint/jsx-a11y.ts
@@ -1,4 +1,4 @@
-import { type Linter } from 'eslint'
+import { ESLint, type Linter } from 'eslint'
 import jsxA11y from 'eslint-plugin-jsx-a11y'
 
 import { astroFiles, javascriptFiles, typescriptFiles } from './shared'
@@ -11,7 +11,7 @@ export const jsxA11yConfig: Linter.Config = {
     ...javascriptFiles.filter(f => f.includes('jsx')),
   ],
   plugins: {
-    'jsx-a11y': jsxA11y,
+    'jsx-a11y': jsxA11y as ESLint.Plugin,
   },
   rules: {
     ...jsxA11y.configs.recommended.rules,

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -14,7 +14,7 @@ export type ReleaseNote = {
   date?: string // optional for twilight
   extra?: string
   fixes?: Fix[]
-  security?: string
+  security?: string | string[]
   knownIssues?: string[]
   features?: string[]
   breakingChanges?: BreakingChange[]


### PR DESCRIPTION
Fixes a few TypeScript typing issues that show up in the current config/data setup.

The release note JSON data can include `security` as either a single entry or an array of entries, so the `ReleaseNote` type now reflects that instead of only allowing `string`s.

The ESLint config updates are small type-only cleanups:

- cast `eslint-plugin-jsx-a11y` through `ESLint.Plugin` where it is registered
- remove the stale `@ts-expect-error` from the `eslint-plugin-import` import now that the package provides types

Changed files:

- `src/release-notes.ts`
- `.eslint/astro.ts`
- `.eslint/jsx-a11y.ts`
- `.eslint/import.ts`