### PR TITLE
chore: update Renovate GitHub Action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Renovate
-        uses: renovatebot/github-action@v42.0.4
+        uses: renovatebot/github-action@v46.1.13
         with:
           configurationFile: renovate.json
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the self-hosted Renovate workflow from `renovatebot/github-action@v42.0.4` to the current `v46.1.13` release.

This keeps the existing schedule, token wiring, and Renovate configuration unchanged while picking up the current action runtime fixes from upstream.