### PR TITLE
Fix typos and invalid Tailwind CSS classes

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -119,7 +119,7 @@ const {
             </li>
             <li>
               <a href="https://github.com/zen-browser/desktop/security/policy" class="font-normal"
-                >{footer.securtiy}</a
+                >{footer.security}</a
               >
             </li>
           </ul>

--- a/src/components/ReleaseNoteItem.astro
+++ b/src/components/ReleaseNoteItem.astro
@@ -151,7 +151,6 @@ generateItems(props.knownIssues, 'known')
                 class="text-xs text-coral underline decoration-wavy opacity-80"
                 href={`https://www.mozilla.org/en-US/firefox/${ffVersion}/releasenotes/`}
                 target="_blank"
-                rel="noopener noreferrer"
               >
                 {releaseNoteItem.firefoxVersion.replace('{version}', ffVersion)}
               </a>
@@ -210,7 +209,7 @@ generateItems(props.knownIssues, 'known')
     }
     {
       isTwilight || isLatest ? (
-        <div class="text-muted-forground flex text-sm opacity-70">
+        <div class="text-muted-foreground flex text-sm opacity-70">
           {isTwilight ? <InfoIcon class="mx-4 my-0 size-6 text-yellow-500" /> : null}
           <p class="m-0">
             {isTwilight ? <>{releaseNoteItem.twilightWarning}</> : null}

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -483,7 +483,7 @@
       "zenMods": "Zen Mods",
       "releaseNotes": "Release Notes",
       "getHelp": "Get Help",
-      "securtiy": "Security",
+      "security": "Security",
       "discord": "Discord",
       "uptimeStatus": "Uptime Status",
       "reportAnIssue": "Report an Issue",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -488,7 +488,7 @@
       "zenMods": "Zen Mods",
       "releaseNotes": "リリースノート",
       "getHelp": "ヘルプ",
-      "securtiy": "Security",
+      "security": "Security",
       "discord": "Discord",
       "uptimeStatus": "稼働状況",
       "reportAnIssue": "問題を報告",

--- a/src/pages/[...locale]/download.astro
+++ b/src/pages/[...locale]/download.astro
@@ -133,7 +133,7 @@ const platformDescriptions = download.platformDescriptions
         <div class="flex cursor-default items-center justify-center gap-3 text-sm font-bold">
           {download.beta}
           <span
-            class="leading-20 caption inline-block flex h-6 items-center rounded-md border border-dark px-2 text-xs"
+            class="caption inline-block flex h-6 items-center rounded-md border border-dark px-2 text-xs leading-normal"
             >BETA</span
           >
         </div>

--- a/src/pages/[...locale]/whatsnew.astro
+++ b/src/pages/[...locale]/whatsnew.astro
@@ -34,7 +34,7 @@ if (latestVersion.version.split('.').length > 2) {
 
 <Layout title={layout.whatsNew.title.replace('{latestVersion.version}', latestVersion.version)}>
   <main
-    class="xl:mt-22 container flex flex-col gap-12 py-12 xl:grid xl:min-h-[calc(100vh-12rem)] xl:grid-cols-[2fr_3fr]"
+    class="container flex flex-col gap-12 py-12 xl:mt-24 xl:grid xl:min-h-[calc(100vh-12rem)] xl:grid-cols-[2fr_3fr]"
   >
     <div class="flex flex-col gap-8">
       <div>


### PR DESCRIPTION
This PR addresses several minor bugs, typos, and CSS inconsistencies found during a codebase audit. These changes improve code quality and ensure that all styles and translations are correctly applied.

**Changes :**
1. Translation Fixes: Renamed the misspelled securtiy key to security in both en/translation.json and ja/translation.json and updated the Footer component reference.
2. CSS Improvements:
Fixed misspelled class text-muted-forground → text-muted-foreground in ReleaseNoteItem.astro.
Corrected invalid Tailwind utility xl:mt-22 → xl:mt-24 in whatsnew.astro.
Corrected invalid Tailwind utility leading-20 → leading-normal in download.astro.
3. HTML Cleanup: Removed a duplicate rel="noopener noreferrer" attribute on an anchor tag in ReleaseNoteItem.astro.

**Motivation**
Found these issues while exploring the repository. Fixing these "low-hanging fruit" bugs helps maintain a high standard of code quality and prevents silent CSS failures.