### PR TITLE
chore(dependabot): assign dependency upkeep owners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     labels:
       - dependencies
       - dependabot
-    reviewers:
+    assignees:
       - taroj1205
       - mauro-valades
     open-pull-requests-limit: 3
@@ -65,7 +65,7 @@ updates:
       - dependencies
       - dependabot
       - github-actions
-    reviewers:
+    assignees:
       - taroj1205
       - mauro-valades
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Switch Dependabot's configured dependency PR owners from requested reviewers to assignees.
- Keep the existing owner list, labels, schedules, grouping, and PR limits unchanged.

Reference: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

## Verification

- `pnpm exec prettier .github/dependabot.yml --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
