### PR TITLE
chore: update ownership routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mauro-valades 
+* @mr-cheffy @taroj1205

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
-# cspell:words valades
 version: 2
 updates:
   - package-ecosystem: npm
@@ -13,7 +12,6 @@ updates:
       - dependabot
     assignees:
       - taroj1205
-      - mauro-valades
     open-pull-requests-limit: 3
     groups:
       security-updates:
@@ -67,7 +65,6 @@ updates:
       - github-actions
     assignees:
       - taroj1205
-      - mauro-valades
     open-pull-requests-limit: 5
     groups:
       security-updates:


### PR DESCRIPTION
## Summary

- Update `CODEOWNERS` to route ownership to `@mr-cheffy` and `@taroj1205`.
- Keep Dependabot assigned to `taroj1205` by removing the previous assignee.

This will be used to assign reviewer automatically.

## Verification

- `pnpm spell`
- `pnpm exec prettier .github/dependabot.yml --check`
- Ruby YAML parse for `.github/dependabot.yml`
- `git diff --check`
