### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug report
+description: Report a problem on the Zen Browser website
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a website issue. Please include enough detail for maintainers to reproduce it.
+
+        Please search open and closed issues before submitting. Someone might have reported the same thing already.
+        Desktop app issues should be reported in https://github.com/zen-browser/desktop/issues.
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: This issue is about the Zen Browser website, not the desktop app.
+          required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Affected page
+      description: Paste the URL or route where the issue appears.
+      placeholder: "https://zen-browser.app/download"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the visible problem or broken behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Home / marketing pages
+        - Download page
+        - Release notes / what's new
+        - Mods pages
+        - Navigation / layout
+        - Translations
+        - Build / CI
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and device
+      placeholder: "Firefox 145 on macOS, Safari on iPhone, etc."
+
+  - type: checkboxes
+    id: ai_use
+    attributes:
+      label: AI use
+      options:
+        - label: I did not use AI to create this issue.
+        - label: If there is no check above, I reviewed the generated content before submitting.
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or recordings
+      description: Drag screenshots, videos, or logs here if useful.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/change_request.yml
+++ b/.github/ISSUE_TEMPLATE/change_request.yml
@@ -1,0 +1,73 @@
+name: Website change request
+description: Suggest a content, UI, translation, or website improvement
+title: "[Change]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a website improvement.
+
+        Please search open and closed issues before submitting. Someone might have requested the same thing already.
+        Desktop app requests should be opened in https://github.com/zen-browser/desktop/issues.
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: This request is about the Zen Browser website, not the desktop app.
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Content / copy
+        - UI / visual design
+        - Download page
+        - Release notes / what's new
+        - Mods pages
+        - Translations
+        - Accessibility
+        - Build / tooling
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Related page or route
+      placeholder: "https://zen-browser.app/..."
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why is this useful?
+      description: Explain the user-facing benefit or problem this solves.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: ai_use
+    attributes:
+      label: AI use
+      options:
+        - label: I did not use AI to create this issue.
+        - label: If there is no check above, I reviewed the generated content before submitting.
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Implementation notes
+      description: Optional screenshots, copy suggestions, links, or technical details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing guide
+    url: https://docs.zen-browser.app/contribute/www
+    about: Read this before opening a contribution PR.
+  - name: Desktop app issues
+    url: https://github.com/zen-browser/desktop/issues
+    about: Report bugs or request changes for the Zen Browser desktop app.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Related issue
+
+<!-- Use "Closes #123", "Fixes #123", "Related #123", or "No linked issue". -->
+
+## Summary
+
+<!-- What changed, and why? Keep this short. -->
+
+## Affected area
+
+<!-- Example: home page, download page, release notes, mods, navigation, translations, tests, CI. -->
+
+## Screenshots or preview
+
+<!-- Required for visible UI changes. Add before/after screenshots, recordings, or a preview URL. -->
+
+## AI use
+
+<!-- Disclose AI-assisted code, copy, translations, screenshots, or other submitted content. -->
+
+- [ ] No AI tools were used.
+- [ ] AI tools were used, and I reviewed the output for accuracy, licensing, and project fit.
+
+## Verification
+
+<!-- List the commands or checks you ran. -->


### PR DESCRIPTION
## Related issue

No linked issue.

## Summary

Adds GitHub issue forms for website bugs and change requests, plus a compact pull request template for public contributions.

## Affected area

GitHub contribution templates.

## Screenshots or preview

Not applicable; this only changes GitHub templates.

## AI use

- [ ] No AI tools were used.
- [x] AI tools were used, and I reviewed the output for accuracy, licensing, and project fit.

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm spell`
- `pnpm test`
- `pnpm build`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/*.yml`
- `pnpm exec playwright test --project=firefox --reporter=list`

Full local `pnpm test:playwright` was not used as the final signal because the local WebKit browser crashed before running one test. The CI-equivalent Firefox project passed.
