### PR TITLE
chore: automate inactive issue cleanup

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,37 @@
+name: Close Stale Issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 2"
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  stale:
+    name: Close Stale Issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure stale label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh label create stale --color ededed --description "No recent activity" --force
+
+      - uses: actions/stale@v10.2.0
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: stale
+          close-issue-reason: not_planned
+          exempt-issue-labels: security,bug,help wanted,good first issue,dependencies,mr. m ⌚
+          stale-issue-message: |
+            This issue has had no activity for 90 days, so it has been marked as stale.
+            It will be closed in 14 days if there is no further activity.
+          close-issue-message: |
+            This issue was closed because it remained inactive for 14 days after being marked stale.
+          operations-per-run: 30

--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
     "createdDesc",
     "daniel",
     "devs",
+    "ededed",
     "ferrocyante",
     "flatpaks",
     "FMPEG",


### PR DESCRIPTION
## Summary

- Add a weekly `actions/stale` workflow for inactive issues
- Mark issues stale after 90 days and close them after 14 additional inactive days
- Keep PR stale handling disabled, and add `ededed` to the cspell dictionary for the stale label color

## Verification

- `pnpm exec prettier --check .github/workflows/close-stale-issues.yml cspell.json`
- `actionlint .github/workflows/close-stale-issues.yml`
- `pnpm exec cspell .github/workflows/close-stale-issues.yml cspell.json`
