### PR TITLE
chore: allow dependabot to open more update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       - dependabot
     assignees:
       - taroj1205
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 10
     groups:
       security-updates:
         applies-to: security-updates
@@ -65,7 +65,7 @@ updates:
       - github-actions
     assignees:
       - taroj1205
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       security-updates:
         applies-to: security-updates


### PR DESCRIPTION
## Summary

- Raise Dependabot open PR limits for npm and GitHub Actions updates to 10.

## Verification

- `pnpm exec prettier .github/dependabot.yml --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

