### PR TITLE
fix: avoid deprecated ESLint config helpers

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,11 +1,10 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { includeIgnoreFile } from '@eslint/compat'
-import { type TSESLint } from '@typescript-eslint/utils'
+import { type Config, defineConfig, globalIgnores } from 'eslint/config'
 import prettierConfig from 'eslint-config-prettier'
 import astro from 'eslint-plugin-astro'
-import tseslint, { configs } from 'typescript-eslint'
+import { configs } from 'typescript-eslint'
 
 // Import modular configurations
 import { astroConfig } from './.eslint/astro'
@@ -24,9 +23,20 @@ const __dirname = dirname(__filename)
 
 const tsConfigPath = resolve(__dirname, './tsconfig.json')
 
-const ignoresConfig = {
-  name: 'eslint/ignores',
-  ignores: [
+const ignoresConfig: Config = globalIgnores(
+  [
+    // Repository ignores
+    '**/.env',
+    '**/.env.production',
+    '**/.DS_Store',
+    '**/.idea/**',
+    '**/.turbo/**',
+    '**/.eslintcache',
+    '**/.cspellcache',
+    '**/npm-debug.log*',
+    '**/yarn-debug.log*',
+    '**/yarn-error.log*',
+
     // Build outputs
     '**/dist/**',
     '**/build/**',
@@ -54,12 +64,10 @@ const ignoresConfig = {
     '**/CHANGELOG.md',
     '**/README.md',
   ],
-} satisfies TSESLint.FlatConfig.Config
+  'eslint/ignores'
+)
 
-const config: TSESLint.FlatConfig.ConfigArray = tseslint.config(
-  // Include .gitignore patterns
-  includeIgnoreFile(resolve(__dirname, '.gitignore')),
-
+const config = defineConfig(
   // Core configurations
   ignoresConfig,
   baseConfig,

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -45,6 +45,8 @@ const ignoresConfig: Config = globalIgnores(
 
     // Test outputs
     '**/coverage/**',
+    '**/blob-report/**',
+    '**/playwright/.cache/**',
     '**/playwright-report/**',
     '**/test-results/**',
 


### PR DESCRIPTION
## Summary

- Replace deprecated ESLint config helpers with `defineConfig` and `globalIgnores` from `eslint/config`
- Preserve the existing ignored paths in the flat config

## Warning addressed

```text
eslint.config.ts:61:3 - warning ts(6387): The signature '(ignoreFilePath: string, name?: string | undefined): ConfigObject<RulesConfig>' of 'includeIgnoreFile' is deprecated.

eslint.config.ts:59:58 - warning ts(6387): The signature '(...configs: InfiniteDepthConfigWithExtends[]): ConfigArray' of 'tseslint.config' is deprecated.

eslint.config.ts:4:10 - warning ts(6385): 'includeIgnoreFile' is deprecated.
```

## Checks

- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
```
Result (75 files):
- 0 errors
- 0 warnings
- 0 hints
```
