### PR TITLE
fix(ci): resolve stale label repository lookup

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Ensure stale label exists
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh label create stale --color ededed --description "No recent activity" --force
 
       - uses: actions/stale@v10.2.0


### PR DESCRIPTION
## Summary

- Pass `GH_REPO` to the stale label creation step so GitHub CLI can target the repository before checkout.
- Keep the stale workflow checkout-free while fixing the repository lookup failure.

## Testing

- actionlint .github/workflows/close-stale-issues.yml
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm spell

## Coverage

Not applicable: this PR only changes a GitHub Actions workflow.
