### PR TITLE
fix(workflow): target stale label repository

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Ensure stale label exists
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh label create stale --color ededed --description "No recent activity" --force
+        run: gh label create stale --repo "$GITHUB_REPOSITORY" --color ededed --description "No recent activity" --force
 
       - uses: actions/stale@v10.2.0
         with:


### PR DESCRIPTION
## Summary
- Pass the current Actions repository to `gh label create` explicitly.
- Avoid relying on local git metadata in the stale issue workflow before checkout.

## Verification
- `actionlint .github/workflows/close-stale-issues.yml`
- `git diff --check`

## Coverage
Not applicable: workflow-only change with no source coverage target.