### PR TITLE
fix(whatsnew): keep Firefox list markers inline

### DIFF
--- a/src/pages/[...locale]/whatsnew.astro
+++ b/src/pages/[...locale]/whatsnew.astro
@@ -46,17 +46,17 @@ if (latestVersion.version.split('.').length > 2) {
       <div>
         <Fragment set:html={whatsNewText[0].replace(/\n/g, '<br>')} />
       </div>
-      <ul class="hidden list-disc flex-col gap-2 xl:container xl:flex">
+      <ul class="hidden list-disc space-y-2 xl:container xl:block">
         <li>
           <a href="https://github.com/zen-browser/desktop/issues/new/choose" target="_blank">
-            <Description class="m-0 text-base font-bold">
+            <Description class="m-0 inline text-base font-bold">
               {whatsNew.reportIssue}
             </Description>
           </a>
         </li>
         <li>
           <a href="https://discord.gg/zen-browser" target="_blank">
-            <Description class="m-0 text-base font-bold">
+            <Description class="m-0 inline text-base font-bold">
               {whatsNew.joinDiscord}
             </Description>
           </a>


### PR DESCRIPTION
## Summary
- Fix the whatsnew desktop link list in Firefox by avoiding flex layout on the `ul`.
- Keep native `list-disc` markers and make the link labels inline so bullets and text stay on one row.

## Issue
- No linked issue.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec prettier --check src/pages/'[...locale]'/whatsnew.astro`
- Firefox Playwright screenshot/DOM check for `/whatsnew`

<!-- manual-coverage-report:start -->
## Coverage

Not collected. This PR changes Astro markup/CSS classes for a browser-specific layout issue and does not add or modify test-covered runtime logic.
<!-- manual-coverage-report:end -->
