### PR TITLE
fix: improve homepage contrast

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -131,7 +131,7 @@ const {
       aria-label="Copyright information"
     >
       <p
-        class="flex justify-center gap-2 lg:justify-start"
+        class="[&_.zen-link]:!text-paper flex justify-center gap-2 lg:justify-start"
         set:html={footer.madeWith.replace('{link}', getLocalePath('/about'))}
       />
     </section>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -29,7 +29,10 @@ const {
             hero.title.map(title =>
               title.text !== '\n' ? (
                 <b
-                  class:list={['font-normal', title.highlight && 'text-coral italic']}
+                  class:list={[
+                    'font-normal',
+                    title.highlight && 'dark:text-coral text-[#bf3316] italic',
+                  ]}
                   style="transform: translateY(20px); opacity: 0.001; filter: blur(4px)"
                 >
                   {title.text}


### PR DESCRIPTION
## Summary

- darken the highlighted "calmer" hero word in light mode so it clears WCAG contrast guidance
- keep the existing coral accent in dark mode, where it already has sufficient contrast
- force the footer "Zen Team" link to use the footer text color so the full "Made with ..." line stays readable in both themes

Closes #898.

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- rendered contrast check on `http://127.0.0.1:3001/`:
  - light hero highlight: 4.96:1
  - dark hero highlight: 5.77:1
  - light footer link: 11.87:1
  - dark footer link: 10.52:1

Used AI assistance to help draft and verify this change; I reviewed the diff and ran the checks above locally.
