### PR TITLE
Add explicit type annotation to CONSTANT export

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,7 +2,13 @@ import { CHECKSUMS } from './checksum'
 import { i18n as I18N } from './i18n'
 import { PUBLIC_ROUTES } from './routes'
 
-export const CONSTANT = {
+interface Constants {
+  I18N: typeof I18N;
+  CHECKSUMS: typeof CHECKSUMS;
+  PUBLIC_ROUTES: typeof PUBLIC_ROUTES;
+}
+
+export const CONSTANT: Constants = {
   I18N,
   CHECKSUMS,
   PUBLIC_ROUTES,


### PR DESCRIPTION
## Problem
The exported constant `CONSTANT` in `src/constants/index.ts` lacked an explicit type annotation. This could lead to ambiguous types in TypeScript, making the code harder to understand and maintain, potentially causing issues with type inference and readability.

## Changes
- Introduced a `Constants` interface to define the shape of the `CONSTANT` object, specifying the types for `I18N`, `CHECKSUMS`, and `PUBLIC_ROUTES` based on their respective imports.
- Added an explicit type annotation to the `CONSTANT` variable using the new interface, ensuring type safety and clarity.

## Verification
- Confirm TypeScript compilation completes without errors (e.g., run `tsc` or similar build process).
- Run existing tests (if available) to ensure no functionality changes or regressions.
- Review the diff to verify the changes align with the intended improvement in type annotations.