### PR TITLE
fix(i18n): correct typo in footer security key

### DIFF
--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -488,7 +488,7 @@
       "zenMods": "Zen Mods",
       "releaseNotes": "リリースノート",
       "getHelp": "ヘルプ",
-      "securtiy": "Security",
+      "security": "Security",
       "discord": "Discord",
       "uptimeStatus": "稼働状況",
       "reportAnIssue": "問題を報告",


### PR DESCRIPTION
Fixed a small typo where "security" was spelled "securtiy" in the japanese translation file keys.