### PR TITLE
fix(i18n): correct footer key reference to fix broken CI build

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -119,7 +119,7 @@ const {
             </li>
             <li>
               <a href="https://github.com/zen-browser/desktop/security/policy" class="font-normal"
-                >{footer.securtiy}</a
+                >{footer.security}</a
               >
             </li>
           </ul>

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -483,7 +483,7 @@
       "zenMods": "Zen Mods",
       "releaseNotes": "Release Notes",
       "getHelp": "Get Help",
-      "securtiy": "Security",
+      "security": "Security",
       "discord": "Discord",
       "uptimeStatus": "Uptime Status",
       "reportAnIssue": "Report an Issue",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -488,7 +488,7 @@
       "zenMods": "Zen Mods",
       "releaseNotes": "リリースノート",
       "getHelp": "ヘルプ",
-      "securtiy": "Security",
+      "security": "Security",
       "discord": "Discord",
       "uptimeStatus": "稼働状況",
       "reportAnIssue": "問題を報告",


### PR DESCRIPTION
Fixed the TypeScript compilation error caused by the typo mismatch. The Footer.astro component has been updated to use the correct {footer.security} key, matching the recently merged translation JSON update. This resolves the failing CI build.