### PR TITLE
feat: fix darken coral accent for WCAG contrast on light surfaces (issue #898)

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -29,7 +29,7 @@ const {
             hero.title.map(title =>
               title.text !== '\n' ? (
                 <b
-                  class:list={['font-normal', title.highlight && 'text-coral italic']}
+                  class:list={['font-normal', title.highlight && 'text-coral-on-paper italic']}
                   style="transform: translateY(20px); opacity: 0.001; filter: blur(4px)"
                 >
                   {title.text}

--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -46,18 +46,20 @@ const {
         <div class="mb-2 font-bold">{menu.gettingStarted}</div>
         <ul class="ml-4 space-y-2">
           <li>
-            <a href={getLocalePath('/mods')} class="text-dark hover:text-coral block"
+            <a href={getLocalePath('/mods')} class="text-dark hover:text-coral-on-paper block"
               >{menu.zenMods}</a
             >
           </li>
           <li>
-            <a href={getLocalePath('/release-notes')} class="text-dark hover:text-coral block"
-              >{menu.releaseNotes}</a
+            <a
+              href={getLocalePath('/release-notes')}
+              class="text-dark hover:text-coral-on-paper block">{menu.releaseNotes}</a
             >
           </li>
           <li>
-            <a href="https://discord.gg/zen-browser" class="text-dark hover:text-coral block"
-              >{menu.discord}</a
+            <a
+              href="https://discord.gg/zen-browser"
+              class="text-dark hover:text-coral-on-paper block">{menu.discord}</a
             >
           </li>
         </ul>
@@ -67,17 +69,17 @@ const {
         <div class="mb-2 font-bold">{menu.usefulLinks}</div>
         <ul class="ml-4 space-y-2">
           <li>
-            <a href={getLocalePath('/donate')} class="text-dark hover:text-coral block"
+            <a href={getLocalePath('/donate')} class="text-dark hover:text-coral-on-paper block"
               >{menu.donate}</a
             >
           </li>
           <li>
-            <a href={getLocalePath('/about')} class="text-dark hover:text-coral block"
+            <a href={getLocalePath('/about')} class="text-dark hover:text-coral-on-paper block"
               >{menu.aboutUs}</a
             >
           </li>
           <li>
-            <a href="https://docs.zen-browser.app" class="text-dark hover:text-coral block"
+            <a href="https://docs.zen-browser.app" class="text-dark hover:text-coral-on-paper block"
               >{menu.documentation}</a
             >
           </li>
@@ -85,20 +87,21 @@ const {
             <a
               href="https://github.com/zen-browser"
               target="_blank"
-              class="text-dark hover:text-coral block">{menu.github}</a
+              class="text-dark hover:text-coral-on-paper block">{menu.github}</a
             >
           </li>
         </ul>
       </li>
       <!-- Extra Links -->
       <li>
-        <a href={getLocalePath('/mods')} class="text-dark hover:text-coral block font-bold"
+        <a href={getLocalePath('/mods')} class="text-dark hover:text-coral-on-paper block font-bold"
           >{menu.mods}</a
         >
       </li>
       <li>
-        <a href={getLocalePath('/download')} class="text-dark hover:text-coral block font-bold"
-          >{menu.download}</a
+        <a
+          href={getLocalePath('/download')}
+          class="text-dark hover:text-coral-on-paper block font-bold">{menu.download}</a
         >
       </li>
     </ul>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -25,7 +25,7 @@ const {
     class="bg-paper relative z-20 container grid w-full grid-cols-2 items-center gap-2 py-3 lg:grid lg:grid-cols-[auto_1fr_auto] lg:py-6"
   >
     <a class="flex items-center gap-2 text-lg font-bold" href={getLocalePath('/')}>
-      <Logo class="text-coral" />
+      <Logo class="text-coral-on-paper" />
       <span>{brand}</span>
     </a>
     <div

--- a/src/components/ReleaseNoteItem.astro
+++ b/src/components/ReleaseNoteItem.astro
@@ -131,7 +131,7 @@ generateItems(props.knownIssues, 'known')
     {
       isTwilight ? (
         <a
-          class="bg-coral text-paper !mb-2 block w-fit rounded-full px-3 py-1 text-xs"
+          class="bg-coral-on-paper text-paper !mb-2 block w-fit rounded-full px-3 py-1 text-xs"
           href={getLocalePath('/download?twilight')}
         >
           {releaseNoteItem.twilight}
@@ -158,7 +158,7 @@ generateItems(props.knownIssues, 'known')
               <span class="text-muted-foreground mx-3 hidden sm:block">•</span>
               <a
                 rel="noopener noreferrer"
-                class="text-coral text-xs underline decoration-wavy opacity-80"
+                class="text-coral-on-paper text-xs underline decoration-wavy opacity-80"
                 href={`https://www.mozilla.org/en-US/firefox/${ffVersion}/releasenotes/`}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -280,7 +280,7 @@ generateItems(props.knownIssues, 'known')
 
     .extra {
       & a {
-        @apply !text-coral underline underline-offset-4;
+        @apply !text-coral-on-paper underline underline-offset-4;
       }
     }
 

--- a/src/components/download/ButtonCard.astro
+++ b/src/components/download/ButtonCard.astro
@@ -21,7 +21,7 @@ const { label, href, checksum } = Astro.props
 <div class="relative flex flex-col">
   <a
     href={href}
-    class="download-link group/download border-subtle hover:border-coral data-[twilight='true']:hover:border-zen-blue flex flex-1 items-center justify-between rounded-2xl border p-4 transition-all duration-200 hover:shadow-sm dark:hover:shadow-md"
+    class="download-link group/download border-subtle hover:border-coral-on-paper data-[twilight='true']:hover:border-zen-blue flex flex-1 items-center justify-between rounded-2xl border p-4 transition-all duration-200 hover:shadow-sm dark:hover:shadow-md"
     rel="noopener noreferrer"
     tabindex="0"
   >
@@ -32,7 +32,7 @@ const { label, href, checksum } = Astro.props
           <span class="group/checksum relative hidden items-center md:flex">
             <button
               type="button"
-              class="checksum-icon-btn text-muted-foreground hover:text-coral focus:ring-coral group-data-[twilight='true']/download:hover:text-zen-blue group-data-[twilight='true']/download:focus:ring-zen-blue flex items-center justify-center rounded-full p-1 transition-colors duration-150 focus:ring-2 focus:outline-none"
+              class="checksum-icon-btn text-muted-foreground hover:text-coral-on-paper focus:ring-coral-on-paper group-data-[twilight='true']/download:hover:text-zen-blue group-data-[twilight='true']/download:focus:ring-zen-blue flex items-center justify-center rounded-full p-1 transition-colors duration-150 focus:ring-2 focus:outline-none"
               aria-label="Show SHA-256 checksum"
               tabindex="0"
             >
@@ -57,7 +57,7 @@ const { label, href, checksum } = Astro.props
               <span class="flex-1 truncate font-mono text-xs">{checksum}</span>
               <button
                 type="button"
-                class="copy-btn bg-coral hover:bg-coral/80 group-data-[twilight='true']/download:bg-zen-blue group-data-[twilight='true']/download:hover:bg-zen-blue/80 rounded px-2 py-1 text-xs text-white"
+                class="copy-btn bg-coral-strong hover:bg-coral-strong/80 group-data-[twilight='true']/download:bg-zen-blue group-data-[twilight='true']/download:hover:bg-zen-blue/80 rounded px-2 py-1 text-xs text-white"
               >
                 {buttonCard.copy}
               </button>
@@ -69,12 +69,12 @@ const { label, href, checksum } = Astro.props
     <div class="flex flex-col items-end gap-2">
       <div class="flex items-center gap-2">
         <span
-          class="release-type-tag bg-coral/10 text-coral group-hover/download:bg-coral/20 group-data-[twilight='true']/download:bg-zen-blue/10 group-data-[twilight='true']/download:text-zen-blue group-data-[twilight='true']/download:group-hover/download:bg-zen-blue/20 rounded-full px-2 py-1 text-xs font-medium transition-colors duration-200"
+          class="release-type-tag bg-coral/10 text-coral-on-paper group-hover/download:bg-coral/20 group-data-[twilight='true']/download:bg-zen-blue/10 group-data-[twilight='true']/download:text-zen-blue group-data-[twilight='true']/download:group-hover/download:bg-zen-blue/20 rounded-full px-2 py-1 text-xs font-medium transition-colors duration-200"
         >
           {buttonCard.beta}
         </span>
         <div
-          class="download-arrow-icon text-muted-foreground border-subtle group-hover/download:border-coral group-hover/download:text-coral group-data-[twilight='true']/download:group-hover/download:border-zen-blue group-data-[twilight='true']/download:group-hover/download:text-zen-blue rounded-xl border p-2 transition-colors duration-200"
+          class="download-arrow-icon text-muted-foreground border-subtle group-hover/download:border-coral-on-paper group-hover/download:text-coral-on-paper group-data-[twilight='true']/download:group-hover/download:border-zen-blue group-data-[twilight='true']/download:group-hover/download:text-zen-blue rounded-xl border p-2 transition-colors duration-200"
         >
           <svg
             width="16"

--- a/src/pages/[...locale]/404.astro
+++ b/src/pages/[...locale]/404.astro
@@ -17,7 +17,7 @@ const {
   <main
     class="container flex min-h-[70vh] flex-col items-center justify-center gap-6 py-24 text-center"
   >
-    <Title class="text-coral text-7xl font-bold md:text-9xl xl:text-9xl"> 404 </Title>
+    <Title class="text-coral-on-paper text-7xl font-bold md:text-9xl xl:text-9xl"> 404 </Title>
     <div class="flex flex-col items-center gap-6">
       <Description class="text-xl md:text-2xl">
         {notFound.title}

--- a/src/pages/[...locale]/download.astro
+++ b/src/pages/[...locale]/download.astro
@@ -152,7 +152,7 @@ const platformDescriptions = download.platformDescriptions
 
   /* Download card icon */
   .download-card__icon {
-    @apply bg-subtle text-coral data-[twilight='true']:text-zen-blue flex h-10 w-10 items-center justify-center rounded-full p-2;
+    @apply bg-subtle text-coral-on-paper data-[twilight='true']:text-zen-blue flex h-10 w-10 items-center justify-center rounded-full p-2;
   }
 
   /* Make FontAwesome icons match size */

--- a/src/pages/[...locale]/release-notes/index.astro
+++ b/src/pages/[...locale]/release-notes/index.astro
@@ -64,7 +64,7 @@ const {
         releaseNotesData.map(note => (
           <button
             aria-label={`Navigate to version ${note.version}`}
-            class="hover:text-coral w-full text-left transition-colors duration-150"
+            class="hover:text-coral-on-paper w-full text-left transition-colors duration-150"
             data-version={note.version}
           >
             {note.version}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,9 @@
 @theme inline {
   --color-paper: var(--zen-paper);
   --color-coral: #f76f53;
+  --color-coral-strong: #a02f14;
+  --color-coral-on-paper: var(--zen-coral-on-paper);
+  --color-coral-on-dark: var(--zen-coral-on-dark);
   --color-dark: var(--zen-dark);
   --color-subtle: var(--zen-subtle);
   --color-muted: var(--zen-muted);
@@ -77,6 +80,10 @@
   --zen-dark: #2e2e2e;
   --zen-muted: rgba(0, 0, 0, 0.05);
   --zen-subtle: rgba(0, 0, 0, 0.05);
+  /* coral fails WCAG contrast against whichever surface is currently light,
+     so these flip opposite to --zen-paper/--zen-dark to stay readable on each */
+  --zen-coral-on-paper: #a02f14;
+  --zen-coral-on-dark: #f76f53;
 }
 
 :root[data-theme='dark'] {
@@ -84,6 +91,8 @@
   --zen-dark: #d1cfc0;
   --zen-muted: rgba(255, 255, 255, 0.05);
   --zen-subtle: rgba(255, 255, 255, 0.1);
+  --zen-coral-on-paper: #f76f53;
+  --zen-coral-on-dark: #a02f14;
 }
 
 @layer base {
@@ -115,7 +124,7 @@ h1 .italic {
 }
 
 .zen-link {
-  @apply text-coral underline underline-offset-4;
+  @apply text-coral-on-dark underline underline-offset-4;
 }
 
 .svg-inline--fa {


### PR DESCRIPTION
Coral text/icons failed contrast against light backgrounds (hero tagline, footer link in dark mode, and several other spots using the same color). Add theme-aware coral-on-paper/coral-on-dark tokens plus a static coral-strong for solid-fill buttons, and apply them across all affected usages.