### PR TITLE
fix(download): clarify Twilight release messaging

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -272,11 +272,11 @@
     "download": {
       "title": "Start your journey",
       "description": "Download Zen for your platform and experience a more mindful internet browsing experience.<br/>Zen is available for macOS, Windows, and Linux.",
-      "twilightInfo": "You're currently in Twilight mode, this means you're downloading the latest experimental features and updates.",
+      "twilightInfo": "You're viewing Twilight releases. These are pre-release builds of Zen Browser with the latest experimental features and updates.",
       "beta": "Zen is currently in ",
       "otherDownload": "If your device has been wrongly detected, <a href='https://github.com/zen-browser/desktop/releases/latest/' class='zen-link'>see other downloads</a>.<br />Please report any issues you encounter on <a href='https://github.com/zen-browser/desktop/issues/new/choose' class='zen-link ml-[1px]'>GitHub</a>.",
       "alertInfo": {
-        "description": "You're currently in Twilight mode, this means you're downloading the latest experimental features and updates."
+        "description": "You're viewing Twilight releases. These are pre-release builds of Zen Browser with the latest experimental features and updates."
       },
       "platformSelector": {
         "title": "Platform Selector",

--- a/src/i18n/ja/translation.json
+++ b/src/i18n/ja/translation.json
@@ -272,11 +272,11 @@
     "download": {
       "title": "Ready to experience Zen?",
       "description": "お使いのプラットフォーム向けにZenをダウンロード。すべてのダウンロードにはSHA256チェックサムが含まれています",
-      "twilightInfo": "現在Twilightモードです。最新の実験的機能とアップデートをダウンロードしています。",
+      "twilightInfo": "Twilightのリリースを表示しています。これらは、Zen Browserの最新の実験的な機能やアップデートを含むプレリリース版です。",
       "beta": "Zen is currently in ",
       "otherDownload": "If your device got wrongly detected, <a href='https://github.com/zen-browser/desktop/releases/latest/' class='zen-link ml-[1px]'>see other downloads</a>.<br />Please report any issues you encounter on <a href='https://github.com/zen-browser/desktop/issues/new/choose' class='zen-link ml-[1px]'>GitHub</a>.",
       "alertInfo": {
-        "description": "You're currently in Twilight mode, this means you're downloading the latest experimental features and updates."
+        "description": "You're viewing Twilight releases. These are pre-release builds of Zen Browser with the latest experimental features and updates."
       },
       "platformSelector": {
         "title": "プラットフォーム選択",


### PR DESCRIPTION
## Summary

This PR clarifies the wording shown on the Twilight download page.

The previous message said:

> "You're currently in Twilight mode"

This could be misleading because the website does not detect whether the user has Twilight installed. The `?twilight` query parameter only switches the download page to Twilight releases.

The message has been updated to clearly indicate that the user is viewing Twilight releases.

## Changes

* Updated the English Twilight download message.
* Updated the Japanese translation to match.
* Clarified that Twilight releases are pre-release builds with experimental features and updates.

No download behavior or Twilight detection logic was changed.


Fixes: #1030 